### PR TITLE
fix container ready bug

### DIFF
--- a/crates/sidecar/src/monitor.rs
+++ b/crates/sidecar/src/monitor.rs
@@ -61,12 +61,12 @@ impl Monitor {
     }
 
     pub fn set_ready(&self) {
-        self.ready.store(true, Ordering::Relaxed);
+        self.ready.store(true, Ordering::SeqCst);
         self.bump();
     }
 
     pub fn state(&self) -> MonitorState {
-        if !self.ready.load(Ordering::Relaxed) {
+        if !self.ready.load(Ordering::SeqCst) {
             return MonitorState::NotReady;
         }
 


### PR DESCRIPTION
I could be way off here, but I wonder if the bug we occasionally see where we don't seem to detect when a container is ready might be caused by a relaxed ordering of the reads / writes for the atomic boolean `ready` value.

Using logs in datadog, I found [a container that had a very long time-to-ready](https://app.datadoghq.com/logs?query=host%3Agke-jamsocket-cluste-jamsocket-cluste-2d01061e-k20z.us-east4-c.c.jamsocket-337914.internal%20service%3Aspawner-sweeper%20container_id%3Ab46f1cd137fdb14deac18014d99bcee7a131bc25a114ce3fd8e2d47524dedd61%20filename%3A0.log&context_event=AQAAAX_b1oFBYbiLPwAAAABBWF9iMW93WUFBQ1Bic3NPa1A1eWdRQUQ&event=AQAAAX_b1oFBYbiLPwAAAABBWF9iMW93WUFBQ1Bic3NPa1A1eWdRQUQ&index=&stream_sort=desc&viz=&from_ts=1648660474090&to_ts=1648660973513&live=false): `c9xhj`. I then searched Stackdriver logs for logs from that container's sidecar (we accidentally filter those out right now from Datadog when we filter out customer application logs - maybe we should fix that?). 

The [logs I found](https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%3D%22spawner-c9xhj%22;timeRange=2022-03-30T16:53:27.580Z%2F2022-03-30T22:53:27.580Z;cursorTimestamp=2022-03-30T17:16:59.199144925Z?authuser=1&project=jamsocket-337914) seemed to indicate that the port was ready fairly quickly:

```
2022-03-30 13:16:43.167 EDT - application - [rayon_sync] Initializing App state
2022-03-30 13:16:43.169 EDT - application - [rayon_sync::state::app] Fetching model and commits data from aws S3
2022-03-30 13:16:43.292 EDT - spawner-sidecar - "Waiting for port to become ready."
2022-03-30 13:16:43.292 EDT - spawner-sidecar - "Port is ready."
2022-03-30 13:16:43.292 EDT - spawner-sidecar - "Proxy started."
2022-03-30 13:16:43.577 EDT - application - [rayon_sync::state::app] Parsing model data
2022-03-30 13:16:43.577 EDT - application - [rayon_sync::state::app] Parsing commits data
2022-03-30 13:16:43.577 EDT - application - [rayon_sync::state::app] Returning AppState
```

This led me to believe that the issue was somewhere between `self.ready.store(true, Ordering::Relaxed)` in `set_ready()` and `self.sender.send(self.state())` in `bump()`.

@paulgb What do you think? Could this relaxed ordering between the write and the read of the `self.ready` value be the culprit?

Found [this little bit](https://doc.rust-lang.org/nomicon/atomics.html#sequentially-consistent) from the Rustonomicon while trying to wrap my head around orderings for atomics in Rust:

> In practice, sequential consistency is rarely necessary for program correctness. However sequential consistency is definitely the right choice if you're not confident about the other memory orders. Having your program run a bit slower than it needs to is certainly better than it running incorrectly!
