### PR TITLE
config to switch linker to mold for linux target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
+rustflags = ["-C", "link-arg=--ld-path=/usr/local/bin/mold"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/local/bin/mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: rui314/setup-mold@v1
     - uses: Swatinem/rust-cache@v1
       with:
         cache-on-failure: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: rui314/setup-mold@v1
     - uses: Swatinem/rust-cache@v1
       with:
         cache-on-failure: true


### PR DESCRIPTION
PROBLEM:
dev hot-rebuilds currently take ~10s on a 4c8t intel laptop
from circa 2017. (rustc 1.61.0)

SOLUTION:
After switching to mold, this time drops to ~3.5s.

FURTHER INFORMATION:
Profiling via rustc --self-profile reveals that most of the time
for a hot reload comes from linking. mold is a faster linker than
lld or ld.

POSSIBLE IMPROVEMENTS:
Switching to rust nightly (currently 1.63.0) yield further 20-30%
improvements.