### PR TITLE
Fix fast build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 target
 .vscode
 .github
-.cargo
 tests
 Dockerfile

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: rui314/setup-mold@v1
     - uses: Swatinem/rust-cache@v1
       with:
         cache-on-failure: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: rui314/setup-mold@v1
     - uses: Swatinem/rust-cache@v1
       with:
         cache-on-failure: true

--- a/fast_build.sh
+++ b/fast_build.sh
@@ -1,0 +1,28 @@
+#!/bin/env bash
+set -reuo pipefail
+IFS=$'\n\t'
+trap '__error_handling__' ERR
+moldPath=1
+clangPath=1
+
+function __error_handling__() {
+  if [[ $moldPath == "" ]]
+  then
+    >&2 echo "mold linker is not installed, please install it"
+  fi
+
+  if [[ $clangPath == "" ]]
+  then
+    >&2 echo "clang is not installed, please install it"
+  fi
+}
+
+#check if mold and clang exist
+moldPath=$(which mold)
+clangPath=$(which clang)
+
+
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="clang"
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=${moldPath}"
+
+cargo build --features=full


### PR DESCRIPTION
PROBLEM:
as mentioned in 86054, hot-reloads take around 10s, mostly due to
linker.

SOLUTION:
use mold, this time via a fast_build script that sets the necessary
cargo env vars, ensures that mold and clang are installed, and runs
cargo build with the correct path for the mold linker.

POSSIBLE IMPROVEMENTS:
may be a good idea to switch the shell script for a zx script. Also
would be nice if `cargo build` automatically ran fast_build.sh as a
wrapper if the host and profile are correct (ie. linux host, with
dev profile)