### PR TITLE
feat: basic tail on backend logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ required-features = ["full"]
 
 [features]
 full = []
+docker-unit-test = []

--- a/src/drone/agent/docker.rs
+++ b/src/drone/agent/docker.rs
@@ -129,8 +129,8 @@ impl DockerInterface {
     pub async fn stop_container(&self, name: &str) -> Result<()> {
         let options = StopContainerOptions { t: 10 };
 
-        if let Ok(val) = self.is_running(name).await {
-            if val.0 {
+        if let Ok(run_state) = self.is_running(name).await {
+            if run_state.0 {
                 self.docker.stop_container(name, Some(options)).await?;
             }
         }
@@ -289,14 +289,15 @@ mod test {
 
         let container_name = "test";
         let image_name = "hello-world";
+        let total_log_lines = 2;
 
         let container_id = docker
             .run_container(&container_name, &image_name, &HashMap::new())
             .await
             .unwrap();
-        let log_lines = docker.get_last_n_log_lines(&container_id, 2).await.unwrap();
+        let log_lines = docker.get_last_n_log_lines(&container_id, total_log_lines).await.unwrap();
 
-        assert_eq!(log_lines.len(), 2);
+        assert_eq!(log_lines.len(), total_log_lines);
         assert_eq!(log_lines[0], " https://docs.docker.com/get-started/\n");
         assert_eq!(log_lines[1], "\n");
 

--- a/src/drone/agent/mod.rs
+++ b/src/drone/agent/mod.rs
@@ -157,6 +157,7 @@ pub async fn run_agent(agent_opts: AgentOptions) -> Result<()> {
                 tokio::spawn(ready_loop(nats, drone_id, cluster));
             }
 
+            // TODO?: this should become listen to drone.{id}.* and handle specific sub-requests (i.e. get logs instead of spawn)
             tracing::info!("Listening for spawn requests.");
             listen_for_spawn_requests(drone_id, docker, nats, agent_opts.host_ip, db).await
         }


### PR DESCRIPTION
Not sure about the specifics but played around with #48. First time using rust so I might be doing some non-idiomatic things. Feel free to decline.

- add optional local docker unit test (hidden via flag since docker might not be installed)
- add simple unit test using hello-world docker image
- add get_last_n_log_lines
- add Destroy EventType
- stop container only if its running
- return actual container name/id via run_container(..)