### PR TITLE
pass in nats subject when init_tracing_with_nats

### DIFF
--- a/src/drone/mod.rs
+++ b/src/drone/mod.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         } => {
             if let Some(nats) = nats {
                 let nats = nats.connection().await?;
-                init_tracing_with_nats(nats)?;
+                init_tracing_with_nats(nats, "logs.drone".to_string())?;
             } else {
                 init_tracing()?;
             }

--- a/src/messages/logging.rs
+++ b/src/messages/logging.rs
@@ -43,7 +43,7 @@ pub struct LogMessage {
 }
 
 impl LogMessage {
-    pub fn subject() -> Subject<LogMessage, NoReply> {
-        Subject::new("logs.drone".to_string())
+    pub fn subject(subject_name: &str) -> Subject<LogMessage, NoReply> {
+        Subject::new(subject_name.to_string())
     }
 }


### PR DESCRIPTION
Passing in the NATS subject to publish logs to allows applications using `init_tracing_with_nats` (like the Jamsocket platform) to publish to something like `logs.platform` instead of `logs.drone`.