### PR TITLE
Cleaner API for duration units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
+ "serde_with",
  "signal-hook",
  "sqlx",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio-stream = "0.1.8"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tracing-stackdriver = { git = "https://github.com/drifting-in-space/tracing-stackdriver" }
+serde_with = "1.14.0"
 
 [[bin]]
 name = "spawner-drone"

--- a/src/drone/agent/executor.rs
+++ b/src/drone/agent/executor.rs
@@ -10,7 +10,6 @@ use anyhow::{anyhow, Result};
 use chrono::Utc;
 use dashmap::DashMap;
 use serde_json::json;
-use tracing::Level;
 use std::{fmt::Debug, net::IpAddr, sync::Arc};
 use tokio::{
     sync::mpsc::{channel, Sender},
@@ -226,7 +225,7 @@ impl Executor {
                         .await?;
                     let next_check = last_active
                         .checked_add_signed(chrono::Duration::from_std(
-                            spawn_request.max_idle_time,
+                            spawn_request.max_idle_secs,
                         )?)
                         .ok_or_else(|| anyhow!("Checked add error."))?;
 

--- a/src/messages/agent.rs
+++ b/src/messages/agent.rs
@@ -5,6 +5,8 @@ use crate::{
 use bollard::auth::DockerCredentials;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::DurationSeconds;
 use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -51,6 +53,7 @@ impl DroneConnectRequest {
 }
 
 /// A message telling a drone to spawn a backend.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SpawnRequest {
     /// The container image to run.
@@ -61,7 +64,8 @@ pub struct SpawnRequest {
     pub backend_id: BackendId,
 
     /// The timeout after which the drone is shut down if no connections are made.
-    pub max_idle_time: Duration,
+    #[serde_as(as = "DurationSeconds")]
+    pub max_idle_secs: Duration,
 
     /// Environment variables to pass in to the container.
     pub env: HashMap<String, String>,

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -27,12 +27,6 @@ test("Drone sends ready messages", async (t) => {
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
   const nats = await connect({ port: natsPort, token: "mytoken" })
-
-  const connectionRequestSubscription =
-    new NatsMessageIterator<DroneConnectRequest>(
-      nats.subscribe("drone.register")
-    )
-
   t.context.runner.runAgent(natsPort)
 
   // Initial handshake.
@@ -86,7 +80,7 @@ test("NATS logs", async (t) => {
   const request: SpawnRequest = {
     image: TEST_IMAGE,
     backend_id: backendId,
-    max_idle_time: { secs: 10, nanos: 0 },
+    max_idle_secs: 10,
     env: {
       PORT: "8080",
     },
@@ -123,7 +117,7 @@ test("Spawn with agent", async (t) => {
   const request: SpawnRequest = {
     image: TEST_IMAGE,
     backend_id: backendId,
-    max_idle_time: { secs: 10, nanos: 0 },
+    max_idle_secs: 10,
     env: {
       PORT: "8080",
     },
@@ -184,7 +178,7 @@ test("Spawn fails during start", async (t) => {
   const request: SpawnRequest = {
     image: TEST_IMAGE,
     backend_id: backendId,
-    max_idle_time: { secs: 10, nanos: 0 },
+    max_idle_secs: 10,
     env: {
       PORT: "8080",
       EXIT_CODE: "1",
@@ -236,7 +230,7 @@ test("Backend fails after ready", async (t) => {
   const request: SpawnRequest = {
     image: TEST_IMAGE,
     backend_id: backendId,
-    max_idle_time: { secs: 10, nanos: 0 },
+    max_idle_secs: 10,
     env: {
       PORT: "8080",
     },

--- a/tests/src/test-end-to-end.ts
+++ b/tests/src/test-end-to-end.ts
@@ -60,7 +60,7 @@ test("Test end-to-end", async (t) => {
     const request: SpawnRequest = {
         image: TEST_IMAGE,
         backend_id: backendId,
-        max_idle_time: { secs: 10, nanos: 0 },
+        max_idle_secs: 10,
         env: {
             PORT: "8080",
         },

--- a/tests/src/util/types.ts
+++ b/tests/src/util/types.ts
@@ -4,15 +4,10 @@ export interface DroneConnectRequest {
     ip: string
 }
 
-export interface Duration {
-    secs: number
-    nanos: number
-}
-
 export interface SpawnRequest {
     image: string
     backend_id: string
-    max_idle_time: Duration
+    max_idle_secs: number
     env: Record<string, string>
     metadata: Record<string, string>
 }


### PR DESCRIPTION
By default, `Duration` serializes to `{secs: number, nsecs: number}`. We don't need the precision of nanoseconds, so just use seconds to serialize.