### PR TITLE
Use a mutex to guard initial DB migration

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -13,14 +13,10 @@ use crate::{
     types::BackendId,
 };
 use chrono::{DateTime, TimeZone, Utc};
-use sqlx::{
-    migrate,
-    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
-    Result, SqlitePool,
-};
+use sqlx::{Result, SqlitePool};
 
 #[allow(unused)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DroneDatabase {
     pool: SqlitePool,
 }
@@ -145,14 +141,4 @@ impl DroneDatabase {
 
         Ok(Utc.timestamp(time, 0))
     }
-}
-
-pub async fn get_db(db_path: &str) -> Result<DroneDatabase> {
-    let co = SqliteConnectOptions::new()
-        .filename(db_path)
-        .create_if_missing(true);
-    let pool = SqlitePoolOptions::new().connect_with(co).await?;
-    migrate!("./migrations").run(&pool).await?;
-
-    Ok(DroneDatabase::new(pool))
 }

--- a/src/database_connection.rs
+++ b/src/database_connection.rs
@@ -1,0 +1,46 @@
+use crate::database::DroneDatabase;
+use anyhow::Result;
+use sqlx::{
+    migrate,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub struct DatabaseConnection {
+    db_path: String,
+    connection: Arc<Mutex<Option<DroneDatabase>>>,
+}
+
+impl PartialEq for DatabaseConnection {
+    fn eq(&self, other: &Self) -> bool {
+        self.db_path == other.db_path
+    }
+}
+
+impl DatabaseConnection {
+    pub fn new(db_path: String) -> Self {
+        DatabaseConnection {
+            db_path,
+            connection: Arc::default(),
+        }
+    }
+
+    pub async fn connection(&self) -> Result<DroneDatabase> {
+        let mut shared_connection = self.connection.lock().unwrap();
+
+        if let Some(connection) = shared_connection.as_ref() {
+            Ok(connection.clone())
+        } else {
+            let co = SqliteConnectOptions::new()
+                .filename(&self.db_path)
+                .create_if_missing(true);
+            let pool = SqlitePoolOptions::new().connect_with(co).await?;
+            migrate!("./migrations").run(&pool).await?;
+
+            let connection = DroneDatabase::new(pool);
+            shared_connection.replace(connection.clone());
+            Ok(connection)
+        }
+    }
+}

--- a/src/drone/agent/mod.rs
+++ b/src/drone/agent/mod.rs
@@ -1,6 +1,7 @@
 use self::{docker::DockerInterface, executor::Executor};
 use crate::{
-    database::{get_db, DroneDatabase},
+    database::DroneDatabase,
+    database_connection::DatabaseConnection,
     drone::cli::IpProvider,
     logging::LogError,
     messages::agent::{
@@ -40,7 +41,7 @@ pub struct DockerOptions {
 
 #[derive(PartialEq, Debug)]
 pub struct AgentOptions {
-    pub db_path: String,
+    pub db: DatabaseConnection,
     pub nats: NatsConnection,
     pub cluster_domain: String,
 
@@ -126,7 +127,7 @@ pub async fn run_agent(agent_opts: AgentOptions) -> Result<()> {
     tracing::info!("Connecting to Docker.");
     let docker = DockerInterface::try_new(&agent_opts.docker_options).await?;
     tracing::info!("Connecting to sqlite.");
-    let db = get_db(&agent_opts.db_path).await?;
+    let db = agent_opts.db.connection().await?;
     let cluster = agent_opts.cluster_domain.to_string();
     let ip = agent_opts.ip.get_ip().await?;
 

--- a/src/drone/cert/mod.rs
+++ b/src/drone/cert/mod.rs
@@ -1,4 +1,5 @@
 use self::https_client::get_https_client;
+use super::cli::CertOptions;
 use crate::{messages::cert::SetAcmeDnsRecord, nats::TypedNats};
 use acme2::{
     gen_rsa_private_key, AccountBuilder, AuthorizationStatus, ChallengeStatus, Csr,
@@ -13,8 +14,6 @@ use openssl::{
 };
 use reqwest::Client;
 use std::{path::Path, time::Duration};
-
-use super::cli::CertOptions;
 
 mod https_client;
 

--- a/src/drone/mod.rs
+++ b/src/drone/mod.rs
@@ -4,8 +4,8 @@ use self::{
     cli::{DronePlan, Opts},
     proxy::serve,
 };
+use crate::logging::TracingHandle;
 use crate::retry::do_with_retry;
-use crate::{database::get_db, logging::TracingHandle};
 use anyhow::Result;
 use clap::Parser;
 use futures::{future::select_all, Future};
@@ -59,8 +59,8 @@ async fn main() -> Result<()> {
             let (result, _, _) = select_all(futs.into_iter()).await;
             result?;
         }
-        DronePlan::DoMigration { db_path } => {
-            get_db(&db_path).await?;
+        DronePlan::DoMigration { db } => {
+            db.connection().await?;
         }
         DronePlan::DoCertificateRefresh(cert_options) => {
             refresh_certificate(&cert_options).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "full")]
 mod database;
 #[cfg(feature = "full")]
+mod database_connection;
+#[cfg(feature = "full")]
 pub mod drone;
 #[cfg(feature = "full")]
 mod keys;


### PR DESCRIPTION
It's possible for two paths to try creating the db at the same time, which seems to be a source of test flakiness. This PR applies the same approach we use for sharing the NATS connection to sharing the database pool.