### PR TITLE
Revert "Abhi/dis 428 spawner pipe docker stats output to nats (#97)"

### DIFF
--- a/src/drone/agent/docker.rs
+++ b/src/drone/agent/docker.rs
@@ -3,8 +3,8 @@ use anyhow::{anyhow, Result};
 use bollard::{
     auth::DockerCredentials,
     container::{
-        Config, CreateContainerOptions, LogOutput, LogsOptions, StartContainerOptions, Stats,
-        StatsOptions, StopContainerOptions,
+        Config, CreateContainerOptions, LogOutput, LogsOptions, StartContainerOptions,
+        StopContainerOptions,
     },
     image::CreateImageOptions,
     models::{EventMessage, HostConfig, PortBinding},
@@ -17,7 +17,6 @@ use tokio_stream::{Stream, StreamExt};
 /// The port in the container which is exposed.
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
-const DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS: u64 = 10;
 
 #[derive(Clone)]
 pub struct DockerInterface {
@@ -162,21 +161,6 @@ impl DockerInterface {
                 tail: "all",
             }),
         )
-    }
-
-    pub fn get_stats(
-        &self,
-        container_name: &str,
-    ) -> impl Stream<Item = Result<Stats, bollard::errors::Error>> {
-        let options = StatsOptions {
-            stream: true,
-            one_shot: false,
-        };
-        self.docker
-            .stats(container_name, Some(options))
-            .throttle(std::time::Duration::from_secs(
-                DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS,
-            ))
     }
 
     #[allow(unused)]

--- a/src/messages/agent.rs
+++ b/src/messages/agent.rs
@@ -2,7 +2,7 @@ use crate::{
     nats::{NoReply, Subject, SubscribeSubject},
     types::{BackendId, DroneId},
 };
-use bollard::{auth::DockerCredentials, container::LogOutput, container::Stats};
+use bollard::{auth::DockerCredentials, container::LogOutput};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -51,61 +51,6 @@ impl DroneLogMessage {
                 None
             }
         }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct DroneStatsMessage {
-    //just fractions of max for now,  go from there
-    pub cpu_use_percent: f64,
-    pub mem_use_percent: f64,
-}
-
-impl DroneStatsMessage {
-    #[must_use]
-    pub fn subject(backend_id: &BackendId) -> Subject<DroneStatsMessage, NoReply> {
-        Subject::new(format!("backend.{}.stats", backend_id.id()))
-    }
-
-    #[must_use]
-    pub fn subscribe_subject() -> SubscribeSubject<DroneStatsMessage, NoReply> {
-        SubscribeSubject::new("backend.*.stats".into())
-    }
-
-    pub fn from_stats_message(stats_message: &Stats) -> Option<DroneStatsMessage> {
-        // based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
-
-        //memory
-        let mem_naive_usage = stats_message.memory_stats.usage.unwrap_or_default();
-        let mem_available = stats_message.memory_stats.limit.unwrap_or(u64::MAX);
-        let mem_stats = stats_message.memory_stats.stats;
-        let cache_mem = match mem_stats {
-            Some(stats) => match stats {
-                bollard::container::MemoryStatsStats::V1(stats) => stats.cache,
-                bollard::container::MemoryStatsStats::V2(stats) => stats.inactive_file,
-            },
-            None => 0,
-        };
-        let used_memory = mem_naive_usage - cache_mem;
-        let mem_use_percent = ((used_memory as f64) / (mem_available as f64)) * 100.0;
-
-        //cpu
-        let cpu_stats = &stats_message.cpu_stats;
-        let precpu_stats = &stats_message.precpu_stats;
-        let cpu_delta = cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage;
-        let sys_cpu_delta = cpu_stats.system_cpu_usage.unwrap_or_default()
-            - precpu_stats.system_cpu_usage.unwrap_or_default();
-        let num_cpus = cpu_stats.online_cpus.unwrap_or_default();
-        let cpu_use_percent =
-            ((cpu_delta as f64) / (sys_cpu_delta as f64)) * (num_cpus as f64) * 100.0;
-
-        //disk
-        //TODO: stream https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect
-
-        Some(DroneStatsMessage {
-            cpu_use_percent,
-            mem_use_percent,
-        })
     }
 }
 

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -130,7 +130,7 @@ test("Spawn with agent", async (t) => {
     new NatsMessageIterator<BackendStateMessage>(
       nats.subscribe(`backend.${backendId}.status`)
     )
-  
+
   t.is("Loading", (await backendStatusSubscription.next())[0].state)
   t.is("Starting", (await backendStatusSubscription.next())[0].state)
   t.is("Ready", (await backendStatusSubscription.next())[0].state)
@@ -146,57 +146,13 @@ test("Spawn with agent", async (t) => {
 
   // Result should respond to ping.
   const result = await axios.get(`http://${address}`)
-  console.log(result)
   t.is(result.status, 200)
   t.is(result.data, "Hello World!")
-  
+
   // Status should update to swept after ~10 seconds.
   t.is("Swept", (await backendStatusSubscription.next())[0].state)
   t.is("Swept", (await t.context.db.getBackend(backendId)).state)
 })
-
-test("stats are acquired", async (t) => {
-  const backendId = generateId()
-  const natsPort = await t.context.docker.runNats()
-  await sleep(1000)
-  const nats = await connect({ port: natsPort, token: "mytoken" })
-  t.context.runner.runAgent(natsPort)
-
-  await expectMessage(t, nats, "drone.register", {
-    cluster: "mydomain.test",
-    ip: "123.12.1.123",
-  }, {
-    Success: {
-      drone_id: 1,
-    },
-  })
-  
-  await sleep(1000)
-  
-
-  // Spawn request.
-  const request: SpawnRequest = {
-    image: TEST_IMAGE,
-    backend_id: backendId,
-    max_idle_secs: 40,
-    env: {
-      PORT: "8080",
-    },
-    metadata: {},
-  }
-  expectResponse(t, nats, "drone.1.spawn", request, true)
-  await sleep(100)
-
-  const statsStatusSubsription = 
-    new NatsMessageIterator<unknown>(
-      nats.subscribe(`backend.${backendId}.stats`, { timeout : 1000000 })
-  )
-  const statsMessage = await statsStatusSubsription.next()
-  const stats= statsMessage[0]
-  t.assert(stats["cpu_use_percent"] > 0 && stats["mem_use_percent"] > 0)
-})
-
-
 
 test("Lifecycle is managed when agent is restarted.", async (t) => {
   const backendId = generateId()


### PR DESCRIPTION
This reverts commit 616afb20e3f0da98fe6b38c69f0c94899142494e.

PROBLEM: when a container is swept, stats continue, except with CPU null
SOLUTION: needs investigation, revert changeset for now and come back to
	  it.