### PR TITLE
Ensure that containers are removed

### DIFF
--- a/src/drone/agent/docker.rs
+++ b/src/drone/agent/docker.rs
@@ -25,7 +25,9 @@ pub struct DockerInterface {
     runtime: Option<String>,
 }
 
+/// Helper trait for swallowing Docker not found errors.
 trait AllowNotFound {
+    /// Swallow a result if it is a success result or a NotFound; propagate it otherwise.
     fn allow_not_found(self) -> Result<(), bollard::errors::Error>;
 }
 

--- a/src/drone/agent/docker.rs
+++ b/src/drone/agent/docker.rs
@@ -25,6 +25,20 @@ pub struct DockerInterface {
     runtime: Option<String>,
 }
 
+trait AllowNotFound {
+    fn allow_not_found(self) -> Result<(), bollard::errors::Error>;
+}
+
+impl<T> AllowNotFound for Result<T, bollard::errors::Error> {
+    fn allow_not_found(self) -> Result<(), bollard::errors::Error> {
+        match self {
+            Ok(_) => Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {status_code: 404, ..}) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
 /// The list of possible container events.
 /// Comes from [Docker documentation](https://docs.docker.com/engine/reference/commandline/events/).
 #[derive(Debug, PartialEq, Eq)]
@@ -201,7 +215,8 @@ impl DockerInterface {
     pub async fn stop_container(&self, name: &str) -> Result<()> {
         let options = StopContainerOptions { t: 10 };
 
-        self.docker.stop_container(name, Some(options)).await?;
+        self.docker.stop_container(name, Some(options)).await.allow_not_found()?;
+        self.docker.remove_container(name, None).await.allow_not_found()?;
 
         Ok(())
     }

--- a/src/drone/agent/executor.rs
+++ b/src/drone/agent/executor.rs
@@ -355,12 +355,11 @@ impl Executor {
             | BackendState::Exited
             | BackendState::Swept => {
                 let container_name = spawn_request.backend_id.to_resource_name();
-                if self.docker.is_running(&container_name).await?.0 {
-                    self.docker
-                        .stop_container(&container_name)
-                        .await
-                        .map_err(|e| anyhow!("Error stopping container: {:?}", e))?;
-                }
+
+                self.docker
+                    .stop_container(&container_name)
+                    .await
+                    .map_err(|e| anyhow!("Error stopping container: {:?}", e))?;
 
                 Ok(None)
             }

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -146,7 +146,6 @@ test("Spawn with agent", async (t) => {
 
   // Result should respond to ping.
   const result = await axios.get(`http://${address}`)
-  console.log(result)
   t.is(result.status, 200)
   t.is(result.data, "Hello World!")
   
@@ -195,8 +194,6 @@ test("stats are acquired", async (t) => {
   const stats= statsMessage[0]
   t.assert(stats["cpu_use_percent"] > 0 && stats["mem_use_percent"] > 0)
 })
-
-
 
 test("Lifecycle is managed when agent is restarted.", async (t) => {
   const backendId = generateId()


### PR DESCRIPTION
Instead of just stopping containers, remove them. Should also cut down on spurious warnings about containers not existing.