### PR TITLE
ensure that container stats collection is stopped when container stat…

### DIFF
--- a/src/drone/agent/executor.rs
+++ b/src/drone/agent/executor.rs
@@ -179,12 +179,18 @@ impl Executor {
 
                     while let Some(v) = stream.next().await {
                         match v {
-                            Ok(v) => {
-                                if let Some(message) = DroneStatsMessage::from_stats_message(&v) {
+                            Ok(v) => match DroneStatsMessage::from_stats_message(&v) {
+                                Some(message) => {
                                     nc.publish(&DroneStatsMessage::subject(&backend_id), &message)
                                         .await?;
                                 }
-                            }
+                                None => {
+                                    let message =
+                                        "failed to get stats (container may have been swept)";
+                                    tracing::warn!(message);
+                                    return Err(anyhow::Error::msg(message));
+                                }
+                            },
                             Err(error) => {
                                 tracing::warn!(?error, "Error encountered sending stats.")
                             }

--- a/src/drone/agent/executor.rs
+++ b/src/drone/agent/executor.rs
@@ -187,7 +187,7 @@ impl Executor {
                                 None => {
                                     let message =
                                         "failed to get stats (container may have been swept)";
-                                    tracing::warn!(message);
+                                    tracing::info!(%backend_id, message);
                                     return Err(anyhow::Error::msg(message));
                                 }
                             },

--- a/src/messages/agent.rs
+++ b/src/messages/agent.rs
@@ -92,12 +92,15 @@ impl DroneStatsMessage {
         //cpu
         let cpu_stats = &stats_message.cpu_stats;
         let precpu_stats = &stats_message.precpu_stats;
-        let cpu_delta = cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage;
-        let sys_cpu_delta = cpu_stats.system_cpu_usage.unwrap_or_default()
-            - precpu_stats.system_cpu_usage.unwrap_or_default();
+        let cpu_delta =
+            (cpu_stats.cpu_usage.total_usage as f64) - (precpu_stats.cpu_usage.total_usage as f64);
+        let sys_cpu_delta = (cpu_stats.system_cpu_usage.unwrap_or_default() as f64)
+            - (precpu_stats.system_cpu_usage.unwrap_or_default() as f64);
         let num_cpus = cpu_stats.online_cpus.unwrap_or_default();
-        let cpu_use_percent =
-            ((cpu_delta as f64) / (sys_cpu_delta as f64)) * (num_cpus as f64) * 100.0;
+        let cpu_use_percent = (cpu_delta / sys_cpu_delta) * (num_cpus as f64) * 100.0;
+        if cpu_use_percent.is_nan() {
+            return None;
+        }
 
         //disk
         //TODO: stream https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -232,8 +232,6 @@ test("stats are killed after container dies", async (t) => {
       nats.subscribe(`backend.${backendId}.stats`, { timeout: 1000000 })
     )
 
-  //TODO: figure out a way to write a test such that
-  //eventually no more stats come
   while (true) {
     //NOTE: this sleep is strongly coupled to 
     //DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SEC in agent/docker.rs

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -196,7 +196,7 @@ test("stats are acquired", async (t) => {
   t.assert(stats["cpu_use_percent"] > 0 && stats["mem_use_percent"] > 0)
 })
 
-test.only("stats are killed after container dies", async (t) => {
+test("stats are killed after container dies", async (t) => {
   const backendId = generateId()
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -196,7 +196,7 @@ test("stats are acquired", async (t) => {
   t.assert(stats["cpu_use_percent"] > 0 && stats["mem_use_percent"] > 0)
 })
 
-test("stats are killed after container dies", async (t) => {
+test.only("stats are killed after container dies", async (t) => {
   const backendId = generateId()
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)
@@ -233,19 +233,19 @@ test("stats are killed after container dies", async (t) => {
       nats.subscribe(`backend.${backendId}.stats`, { timeout: 1000000 })
     )
 
-  try {
-    while (true) {
-      //NOTE: this sleep is strongly coupled to 
-      //DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SEC in agent/docker.rs
-      await Promise.race([statsStatusSubsription.next(), sleep(11000)])
-        .then(val => { if (!val) { throw ("DONE") } else { console.log(val) } })
+  //TODO: figure out a way to write a test such that
+  //eventually no more stats come
+  while (true) {
+    //NOTE: this sleep is strongly coupled to 
+    //DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SEC in agent/docker.rs
+    let newMessage = await Promise.race([statsStatusSubsription.next(), sleep(11000)])
+    if (!newMessage) {
+      break;
+    } else {
+      console.log(newMessage[0])
     }
   }
-  catch (e) {
-    //TODO: figure out a way to write a test such that
-    //eventually no more stats come
-    t.pass("Eventually, stats should stop coming")
-  }
+  t.pass("Eventually, stats should stop coming")
 })
 
 


### PR DESCRIPTION
…s no longer being reported


fixes bug with 'cpu_usage:null' reports in nats for swept backends