### PR TITLE
Refactor EAB data flow

### DIFF
--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -268,7 +268,7 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
   const request: SpawnRequest = {
     image: TEST_IMAGE,
     backend_id: backendId,
-    max_idle_secs: 10,
+    max_idle_secs: 20,
     env: {
       PORT: "8080",
     },
@@ -281,15 +281,19 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
       nats.subscribe(`backend.${backendId}.status`)
     )
 
+  console.log('here5')  
   await expectResponse(t, nats, "drone.1.spawn", request, true)
+  console.log('here0')
 
   t.is("Loading", (await backendStatusSubscription.next())[0].state)
   t.is("Starting", (await backendStatusSubscription.next())[0].state)
   t.is("Ready", (await backendStatusSubscription.next())[0].state)
+  console.log('here1')
 
   // Restart drone.
   t.context.runner.drop()
   t.context.runner.runAgent(natsPort)
+  console.log('here3')
   t.timeout(5000, "Failed while waiting for drone register request.")
   await expectMessage(t, nats, "drone.register", {
     cluster: "mydomain.test",
@@ -299,9 +303,10 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
       drone_id: 1,
     },
   })
+  console.log('here2')
 
   // Status should update to swept after ~10 seconds.
-  t.timeout(10000, "Failed while waiting for backend to be swept.")
+  t.timeout(20000, "Failed while waiting for backend to be swept.")
   t.is("Swept", (await backendStatusSubscription.next())[0].state)
   t.is("Swept", (await t.context.db.getBackend(backendId)).state)
 })

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -53,7 +53,7 @@ test("Drone sends ready messages", async (t) => {
 })
 
 test("NATS logs", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId("nats-logs")
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -95,7 +95,7 @@ test("NATS logs", async (t) => {
 })
 
 test("Spawn with agent", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('spawn-with-agent')
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -155,7 +155,7 @@ test("Spawn with agent", async (t) => {
 })
 
 test("stats are acquired", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('stats-acquired')
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)
   const nats = await connect({ port: natsPort, token: "mytoken" })
@@ -196,7 +196,7 @@ test("stats are acquired", async (t) => {
 })
 
 test("stats are killed after container dies", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('stats-killed')
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)
   const nats = await connect({ port: natsPort, token: "mytoken" })
@@ -247,7 +247,7 @@ test("stats are killed after container dies", async (t) => {
 
 
 test("Lifecycle is managed when agent is restarted.", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('lifecycle-managed-restart')
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -307,7 +307,7 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
 })
 
 test("Spawn fails during start", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('spawn-fails')
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -359,7 +359,7 @@ test("Spawn fails during start", async (t) => {
 })
 
 test("Backend fails after ready", async (t) => {
-  const backendId = generateId()
+  const backendId = generateId('backend-fails-after-ready')
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -351,7 +351,7 @@ test("Spawn fails during start", async (t) => {
 
   t.timeout(100, "Waiting for loading message")
   t.is("Loading", (await backendStatusSubscription.next())[0].state)
-  t.timeout(10000, "Waiting for starting message")
+  t.timeout(60000, "Waiting for starting message")
   t.is("Starting", (await backendStatusSubscription.next())[0].state)
   t.timeout(5000, "Waiting for ErrorStarting message")
   t.is("ErrorStarting", (await backendStatusSubscription.next())[0].state)

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -1,7 +1,6 @@
 import axios from "axios"
 import { connect } from "nats"
 import { TestEnvironment } from "./util/environment.js"
-import { generateId } from "./util/id_gen.js"
 import { TEST_IMAGE } from "./util/images.js"
 import { expectMessage, expectResponse, NatsMessageIterator } from "./util/nats.js"
 import { sleep } from "./util/sleep.js"
@@ -53,7 +52,7 @@ test("Drone sends ready messages", async (t) => {
 })
 
 test("NATS logs", async (t) => {
-  const backendId = generateId("nats-logs")
+  const backendId = 'nats-logs'
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -95,7 +94,7 @@ test("NATS logs", async (t) => {
 })
 
 test("Spawn with agent", async (t) => {
-  const backendId = generateId('spawn-with-agent')
+  const backendId = 'spawn-with-agent'
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -155,7 +154,7 @@ test("Spawn with agent", async (t) => {
 })
 
 test("stats are acquired", async (t) => {
-  const backendId = generateId('stats-acquired')
+  const backendId = 'stats-acquired'
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)
   const nats = await connect({ port: natsPort, token: "mytoken" })
@@ -196,7 +195,7 @@ test("stats are acquired", async (t) => {
 })
 
 test("stats are killed after container dies", async (t) => {
-  const backendId = generateId('stats-killed')
+  const backendId = 'stats-killed'
   const natsPort = await t.context.docker.runNats()
   await sleep(1000)
   const nats = await connect({ port: natsPort, token: "mytoken" })
@@ -247,7 +246,7 @@ test("stats are killed after container dies", async (t) => {
 
 
 test("Lifecycle is managed when agent is restarted.", async (t) => {
-  const backendId = generateId('lifecycle-managed-restart')
+  const backendId = 'lifecycle-managed-restart'
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -307,7 +306,7 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
 })
 
 test("Spawn fails during start", async (t) => {
-  const backendId = generateId('spawn-fails')
+  const backendId = 'spawn-fails'
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)
@@ -359,7 +358,7 @@ test("Spawn fails during start", async (t) => {
 })
 
 test("Backend fails after ready", async (t) => {
-  const backendId = generateId('backend-fails-after-ready')
+  const backendId = 'backend-fails-after-ready'
 
   const natsPort = await t.context.docker.runNats()
   await sleep(100)

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -238,8 +238,6 @@ test("Stats are killed after container dies", async (t) => {
     let newMessage = await Promise.race([statsStatusSubsription.next(), sleep(11000)])
     if (!newMessage) {
       break;
-    } else {
-      console.log(newMessage[0])
     }
   }
   t.pass("Eventually, stats should stop coming")
@@ -281,19 +279,15 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
       nats.subscribe(`backend.${backendId}.status`)
     )
 
-  console.log('here5')  
   await expectResponse(t, nats, "drone.1.spawn", request, true)
-  console.log('here0')
 
   t.is("Loading", (await backendStatusSubscription.next())[0].state)
   t.is("Starting", (await backendStatusSubscription.next())[0].state)
   t.is("Ready", (await backendStatusSubscription.next())[0].state)
-  console.log('here1')
 
   // Restart drone.
   t.context.runner.drop()
   t.context.runner.runAgent(natsPort)
-  console.log('here3')
   t.timeout(5000, "Failed while waiting for drone register request.")
   await expectMessage(t, nats, "drone.register", {
     cluster: "mydomain.test",
@@ -303,7 +297,6 @@ test("Lifecycle is managed when agent is restarted.", async (t) => {
       drone_id: 1,
     },
   })
-  console.log('here2')
 
   // Status should update to swept after ~10 seconds.
   t.timeout(20000, "Failed while waiting for backend to be swept.")

--- a/tests/src/test-agent.ts
+++ b/tests/src/test-agent.ts
@@ -350,7 +350,7 @@ test("Spawn fails during start", async (t) => {
 
   t.timeout(100, "Waiting for loading message")
   t.is("Loading", (await backendStatusSubscription.next())[0].state)
-  t.timeout(5000, "Waiting for starting message")
+  t.timeout(10000, "Waiting for starting message")
   t.is("Starting", (await backendStatusSubscription.next())[0].state)
   t.timeout(5000, "Waiting for ErrorStarting message")
   t.is("ErrorStarting", (await backendStatusSubscription.next())[0].state)

--- a/tests/src/test-cert-refresh.ts
+++ b/tests/src/test-cert-refresh.ts
@@ -37,7 +37,7 @@ test("Generate certificate", async (t) => {
     pebble
   )
 
-  t.timeout(5000, "Waiting for DNS message.")
+  t.timeout(10000, "Waiting for DNS message.")
   const [val, msg] = await sub.next()
   t.timeout(1000, "Responding to message.")
   await msg.respond(JSON_CODEC.encode(true))
@@ -50,7 +50,6 @@ test("Generate certificate", async (t) => {
 
   t.assert(validateCertificateKeyPair(keyPair))
 })
-
 
 test("Generate cert with EAB credentials", async (t) => {
   const natsPort = await t.context.docker.runNats()
@@ -79,7 +78,7 @@ test("Generate cert with EAB credentials", async (t) => {
     { kid: 'kid-1', key: "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W" }
   )
 
-  t.timeout(5000, "Waiting for DNS message.")
+  t.timeout(10000, "Waiting for DNS message.")
   const [val, msg] = await sub.next()
   t.timeout(1000, "Responding to message")
   await msg.respond(JSON_CODEC.encode(true))
@@ -90,72 +89,4 @@ test("Generate cert with EAB credentials", async (t) => {
   t.timeout(30000, "Waiting for certificate to refresh.")
   await certRefreshPromise
   t.assert(validateCertificateKeyPair(keyPair))
-})
-
-test("incorrect eab credentials cause panic", async (t) => {
-  const natsPort = await t.context.docker.runNats()
-  const isEab = true
-  const pebble = await t.context.docker.runPebble(isEab)
-  await waitPort({port:pebble.port, protocol: 'https'})
-  await waitPort({port: natsPort})
-  /* to exercise the certificate code paths, spawner requires a 
-     functioning NATS server */
-  const nats = await connect({ port: natsPort, token: "mytoken" })
-
-  mkdirSync(t.context.tempdir.path("keys"))
-
-  const keyPair = new KeyCertPair(
-    t.context.tempdir.path("keys/cert.key"),
-    t.context.tempdir.path("keys/cert.pem")
-  )
-
-  /* NOTE: This test is remarkably brittle.
-     The idea is that if kid or key are invalid,
-     the server will throw an error. However, if
-     there is no nats subscriber listening 
-     on acme.set_dns_record and responding with true,
-     it will error out with a nats error, notwithstanding
-     the fact that the kid and key are fine. The *problem*
-     is that t.context.runner cannot differentiate
-     between different kinds of errors. One solution would be
-     to parse stdout. Another is the one used here, where the
-     every message to acme.set_dns_record is responded to with
-     true.
-  */
-  nats.subscribe("acme.set_dns_record", { callback: (_, msg) => { msg.respond(JSON_CODEC.encode(true)) } })
-
-  {
-    const certRefreshPromise = t.context.runner.certRefresh(
-      keyPair,
-      natsPort,
-      pebble,
-      { kid: 'badkid', key: "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W" }
-    )
-    await t.throwsAsync(certRefreshPromise, { instanceOf: Error }, "spawner does not error out when acme_kid invalid")
-  }
-
-
-  {
-    const certRefreshPromise = t.context.runner.certRefresh(
-      keyPair,
-      natsPort,
-      pebble,
-      { kid: 'kid-1', key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
-    )
-    await t.throwsAsync(certRefreshPromise, { instanceOf: Error }, "spawner does not error out when acme_key invalid")
-  }
-
-  /*sanity check to see if correct response works*/
-  {
-    await t.context.runner.certRefresh(
-      keyPair,
-      natsPort,
-      pebble,
-      { kid: 'kid-1', key: "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W"}
-    )
-
-    t.assert(validateCertificateKeyPair(keyPair))
-
-  }
-
 })

--- a/tests/src/test-end-to-end.ts
+++ b/tests/src/test-end-to-end.ts
@@ -4,7 +4,6 @@ import { mkdirSync } from "fs"
 import { connect } from "nats"
 import { KeyCertPair } from "./util/certificates.js"
 import { TestEnvironment } from "./util/environment.js"
-import { generateId } from "./util/id_gen.js"
 import { TEST_IMAGE } from "./util/images.js"
 import { JSON_CODEC, NatsMessageIterator } from "./util/nats.js"
 import { sleep } from "./util/sleep.js"
@@ -13,7 +12,7 @@ import { BackendStateMessage, DnsMessage, DroneConnectRequest, SpawnRequest } fr
 const test = TestEnvironment.wrappedTestFunction()
 
 test("Test end-to-end", async (t) => {
-    const backendId = generateId()
+    const backendId = 'end-to-end'
 
     const pebble = await t.context.docker.runPebble()
     const natsPort = await t.context.docker.runNats()

--- a/tests/src/util/id_gen.ts
+++ b/tests/src/util/id_gen.ts
@@ -1,3 +1,3 @@
-export function generateId(): string {
-  return Math.random().toString(36).slice(2, 8)
+export function generateId(prefix?: string): string {
+  return (prefix ? (prefix + '-') : '') + Math.random().toString(36).slice(2, 8)
 }

--- a/tests/src/util/id_gen.ts
+++ b/tests/src/util/id_gen.ts
@@ -1,3 +1,0 @@
-export function generateId(prefix?: string): string {
-  return (prefix ? (prefix + '-') : '') + Math.random().toString(36).slice(2, 8)
-}


### PR DESCRIPTION
This is a light refactoring that simplifies data flow of EAB kid/keys. The main thing I am aiming for here are:
- Fuse together EAB key and kid to simplify data flow inside the codebase.
- Handle missing key/kid early so that they are an error at the parse stage.
- Handle base64-decoding early so that it is an error at the parse stage.

I also removed the failure test. In general I like tests of failure cases, but in this case the failure isn't particularly interesting (we're effectively just testing for a non-zero exit code), and the test was causing me other problems with flakiness.