### PR TITLE
Add backend.:id.terminate nats endpoint

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -31,7 +31,10 @@ impl TypedMessage for DroneLogMessage {
 }
 
 impl DroneLogMessage {
-    pub fn from_log_message(backend_id: &BackendId, log_message: &LogOutput) -> Option<DroneLogMessage> {
+    pub fn from_log_message(
+        backend_id: &BackendId,
+        log_message: &LogOutput,
+    ) -> Option<DroneLogMessage> {
         match log_message {
             bollard::container::LogOutput::StdErr { message } => Some(DroneLogMessage {
                 backend_id: backend_id.clone(),
@@ -90,7 +93,10 @@ impl BackendStatsMessage {
 }
 
 impl BackendStatsMessage {
-    pub fn from_stats_message(backend_id: &BackendId, stats_message: &Stats) -> Option<BackendStatsMessage> {
+    pub fn from_stats_message(
+        backend_id: &BackendId,
+        stats_message: &Stats,
+    ) -> Option<BackendStatsMessage> {
         // based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
 
         //memory
@@ -227,6 +233,26 @@ impl SpawnRequest {
     }
 }
 
+/// A message telling a drone to terminate a backend.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TerminationRequest {
+    pub backend_id: BackendId,
+}
+
+impl TypedMessage for TerminationRequest {
+    type Response = bool;
+
+    fn subject(&self) -> Subject<Self> {
+        Subject::new(format!("backend.{}.terminate", self.backend_id.id()))
+    }
+}
+
+impl TerminationRequest {
+    #[must_use]
+    pub fn subscribe_subject() -> SubscribeSubject<TerminationRequest> {
+        SubscribeSubject::new("backend.*.terminate".into())
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendState {

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -1,5 +1,5 @@
+use crate::nats::{Subject, SubscribeSubject, TypedMessage};
 use serde::{Deserialize, Serialize};
-use crate::nats::{Subject, TypedMessage, SubscribeSubject};
 
 /// A request from the drone to the DNS server telling it to set
 /// a TXT record on the given domain with the given value.

--- a/core/src/messages/logging.rs
+++ b/core/src/messages/logging.rs
@@ -1,3 +1,4 @@
+use crate::nats::{NoReply, Subject, TypedMessage};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use core::str::FromStr;
@@ -6,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use tracing::Level;
-use crate::nats::{NoReply, Subject, TypedMessage};
 
 #[derive(Debug)]
 pub struct SerializableLevel(pub Level);

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -204,7 +204,7 @@ where
 
 impl<T> TypedSubscription<T>
 where
-    T: TypedMessage
+    T: TypedMessage,
 {
     fn new(subscription: Subscriber, nc: Client) -> Self {
         TypedSubscription {
@@ -288,11 +288,7 @@ impl TypedNats {
         TypedNats { nc, jetstream }
     }
 
-    pub async fn get_latest<T>(
-        &self,
-        subject: &Subject<T>,
-        stream_name: &str,
-    ) -> Result<Option<T>>
+    pub async fn get_latest<T>(&self, subject: &Subject<T>, stream_name: &str) -> Result<Option<T>>
     where
         T: TypedMessage<Response = NoReply>,
     {

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -504,6 +504,7 @@ async fn handle_termination_request() -> Result<()> {
     let mut controller_mock = MockController::new(nats.clone()).await?;
 
     let mut request = base_spawn_request();
+    request.max_idle_secs = Duration::from_secs(10000);
 
     controller_mock
         .expect_handshake(request.drone_id, agent.ip)
@@ -520,11 +521,14 @@ async fn handle_termination_request() -> Result<()> {
         .wait_for_state(BackendState::Ready, 60_000)
         .await?;
 
+    /*
     let proxy_route = agent
         .db
         .get_proxy_route(request.backend_id.id())
         .await?
         .expect("Expected proxy route.");
+    */
+    /*
     tokio::spawn(async move {
         loop {
             let result = reqwest::get(format!("http://{}/", proxy_route)).await;
@@ -532,6 +536,7 @@ async fn handle_termination_request() -> Result<()> {
             std::thread::sleep(std::time::Duration::from_secs(1));
         }
     });
+    */
 
     let termination_request = TerminationRequest {
         backend_id: request.backend_id.clone(),

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -504,6 +504,7 @@ async fn handle_termination_request() -> Result<()> {
     let mut controller_mock = MockController::new(nats.clone()).await?;
 
     let mut request = base_spawn_request();
+    //ensure spawnee lives long enough to be terminated
     request.max_idle_secs = Duration::from_secs(10000);
 
     controller_mock
@@ -520,23 +521,6 @@ async fn handle_termination_request() -> Result<()> {
     state_subscription
         .wait_for_state(BackendState::Ready, 60_000)
         .await?;
-
-    /*
-    let proxy_route = agent
-        .db
-        .get_proxy_route(request.backend_id.id())
-        .await?
-        .expect("Expected proxy route.");
-    */
-    /*
-    tokio::spawn(async move {
-        loop {
-            let result = reqwest::get(format!("http://{}/", proxy_route)).await;
-            tracing::info!(?result);
-            std::thread::sleep(std::time::Duration::from_secs(1));
-        }
-    });
-    */
 
     let termination_request = TerminationRequest {
         backend_id: request.backend_id.clone(),

--- a/dev/tests/cert.rs
+++ b/dev/tests/cert.rs
@@ -29,7 +29,9 @@ struct DummyDnsHandler {
 impl DummyDnsHandler {
     pub async fn new(conn: &TypedNats, expect_domain: &str) -> Result<DummyDnsHandler> {
         let expect_domain = expect_domain.to_owned();
-        let mut dns_sub = conn.subscribe(SetAcmeDnsRecord::subscribe_subject()).await?;
+        let mut dns_sub = conn
+            .subscribe(SetAcmeDnsRecord::subscribe_subject())
+            .await?;
         let handle = spawn_timeout(10_000, "Should get ACME DNS request.", async move {
             let message = dns_sub.next().await.unwrap().unwrap();
             assert_eq!(expect_domain, message.value.cluster);

--- a/drone/src/drone/agent/executor.rs
+++ b/drone/src/drone/agent/executor.rs
@@ -96,9 +96,10 @@ impl Executor {
             .log_error();
 
         self.nc
-            .publish(
-                &BackendStateMessage::new(BackendState::Loading, spawn_request.backend_id.clone()),
-            )
+            .publish(&BackendStateMessage::new(
+                BackendState::Loading,
+                spawn_request.backend_id.clone(),
+            ))
             .await
             .log_error();
 
@@ -109,7 +110,7 @@ impl Executor {
         &self,
         termination_request: &TerminationRequest,
     ) -> Result<(), anyhow::Error> {
-        tracing::info!("Trying to terminate!");
+        tracing::info!(backend_id=%termination_request.backend_id, "Trying to terminate backend");
         self.docker
             .stop_container(&termination_request.backend_id.to_resource_name())
             .await
@@ -152,9 +153,10 @@ impl Executor {
                     while let Some(v) = stream.next().await {
                         match v {
                             Ok(v) => {
-                                if let Some(message) = DroneLogMessage::from_log_message(&backend_id, &v) {
-                                    nc.publish(&message)
-                                        .await?;
+                                if let Some(message) =
+                                    DroneLogMessage::from_log_message(&backend_id, &v)
+                                {
+                                    nc.publish(&message).await?;
                                 }
                             }
                             Err(error) => {
@@ -184,12 +186,10 @@ impl Executor {
 
                     while let Some(v) = stream.next().await {
                         match v {
-                            Ok(v) => match BackendStatsMessage::from_stats_message(&backend_id, &v) {
+                            Ok(v) => match BackendStatsMessage::from_stats_message(&backend_id, &v)
+                            {
                                 Some(message) => {
-                                    nc.publish(
-                                        &message,
-                                    )
-                                    .await?;
+                                    nc.publish(&message).await?;
                                 }
                                 None => {
                                     let message =
@@ -253,9 +253,10 @@ impl Executor {
                         .await
                         .log_error();
                     self.nc
-                        .publish(
-                            &BackendStateMessage::new(state, spawn_request.backend_id.clone()),
-                        )
+                        .publish(&BackendStateMessage::new(
+                            state,
+                            spawn_request.backend_id.clone(),
+                        ))
                         .await
                         .log_error();
                 }

--- a/drone/src/drone/agent/executor.rs
+++ b/drone/src/drone/agent/executor.rs
@@ -9,6 +9,7 @@ use dashmap::DashMap;
 use dis_spawner::{
     messages::agent::{
         BackendState, BackendStateMessage, BackendStatsMessage, DroneLogMessage, SpawnRequest,
+        TerminationRequest,
     },
     nats::TypedNats,
     types::BackendId,
@@ -102,6 +103,16 @@ impl Executor {
             .log_error();
 
         self.run_backend(spawn_request, BackendState::Loading).await
+    }
+
+    pub async fn kill_backend(
+        &self,
+        termination_request: &TerminationRequest,
+    ) -> Result<(), anyhow::Error> {
+        tracing::info!("Trying to terminate!");
+        self.docker
+            .stop_container(&termination_request.backend_id.to_resource_name())
+            .await
     }
 
     pub async fn resume_backends(self: &Arc<Self>) -> Result<()> {

--- a/drone/src/drone/agent/mod.rs
+++ b/drone/src/drone/agent/mod.rs
@@ -14,7 +14,7 @@ use dis_spawner::{
 };
 use http::Uri;
 use hyper::Client;
-use std::{net::IpAddr, sync::Arc, time::Duration};
+use std::{net::IpAddr, time::Duration};
 
 mod docker;
 mod executor;
@@ -62,7 +62,7 @@ pub async fn wait_port_ready(port: u16, host_ip: IpAddr) -> Result<()> {
 
 async fn listen_for_spawn_requests(
     drone_id: DroneId,
-    executor: Arc<Executor>,
+    executor: Executor,
     nats: TypedNats,
 ) -> Result<()> {
     let mut sub = nats
@@ -90,7 +90,7 @@ async fn listen_for_spawn_requests(
     }
 }
 
-async fn listen_for_termination_requests(executor: Arc<Executor>, nats: TypedNats) -> Result<()> {
+async fn listen_for_termination_requests(executor: Executor, nats: TypedNats) -> Result<()> {
     let mut sub = nats
         .subscribe(TerminationRequest::subscribe_subject())
         .await?;
@@ -159,7 +159,7 @@ pub async fn run_agent(agent_opts: AgentOptions) -> Result<()> {
 
     match result {
         DroneConnectResponse::Success { drone_id } => {
-            let executor = Arc::new(Executor::new(docker, db, nats.clone()));
+            let executor = Executor::new(docker, db, nats.clone());
             let result = tokio::try_join!(
                 ready_loop(nats.clone(), drone_id, cluster.clone()),
                 listen_for_spawn_requests(drone_id, executor.clone(), nats.clone()),

--- a/drone/src/drone/agent/mod.rs
+++ b/drone/src/drone/agent/mod.rs
@@ -69,6 +69,7 @@ async fn listen_for_spawn_requests(
         .subscribe(&SpawnRequest::subscribe_subject(drone_id))
         .await?;
     executor.resume_backends().await?;
+    tracing::info!("Listening for spawn requests.");
 
     loop {
         let req = sub.next().await;
@@ -94,6 +95,7 @@ async fn listen_for_termination_requests(executor: Executor, nats: TypedNats) ->
     let mut sub = nats
         .subscribe(TerminationRequest::subscribe_subject())
         .await?;
+    tracing::info!("Listening for termination requests.");
     loop {
         let req = sub.next().await;
         match req {
@@ -165,7 +167,6 @@ pub async fn run_agent(agent_opts: AgentOptions) -> Result<()> {
                 listen_for_spawn_requests(drone_id, executor.clone(), nats.clone()),
                 listen_for_termination_requests(executor.clone(), nats.clone())
             );
-            tracing::info!("Listening for spawn requests.");
             result.map(|_| ())
         }
         DroneConnectResponse::NoSuchCluster => Err(anyhow!(

--- a/drone/src/drone/agent/mod.rs
+++ b/drone/src/drone/agent/mod.rs
@@ -1,13 +1,11 @@
 use self::{docker::DockerInterface, executor::Executor};
-use crate::{
-    database::DroneDatabase, database_connection::DatabaseConnection, drone::cli::IpProvider,
-};
+use crate::{database_connection::DatabaseConnection, drone::cli::IpProvider};
 use anyhow::{anyhow, Result};
 use dis_spawner::{
     logging::LogError,
     messages::agent::{
         BackendStateMessage, DroneConnectRequest, DroneConnectResponse, DroneStatusMessage,
-        SpawnRequest,
+        SpawnRequest, TerminationRequest,
     },
     nats::TypedNats,
     nats_connection::NatsConnection,
@@ -64,12 +62,12 @@ pub async fn wait_port_ready(port: u16, host_ip: IpAddr) -> Result<()> {
 
 async fn listen_for_spawn_requests(
     drone_id: DroneId,
-    docker: DockerInterface,
+    executor: Arc<Executor>,
     nats: TypedNats,
-    db: DroneDatabase,
 ) -> Result<()> {
-    let mut sub = nats.subscribe(&SpawnRequest::subscribe_subject(drone_id)).await?;
-    let executor = Arc::new(Executor::new(docker, db, nats));
+    let mut sub = nats
+        .subscribe(&SpawnRequest::subscribe_subject(drone_id))
+        .await?;
     executor.resume_backends().await?;
 
     loop {
@@ -92,8 +90,32 @@ async fn listen_for_spawn_requests(
     }
 }
 
+async fn listen_for_termination_requests(executor: Arc<Executor>, nats: TypedNats) -> Result<()> {
+    let mut sub = nats
+        .subscribe(TerminationRequest::subscribe_subject())
+        .await?;
+    loop {
+        let req = sub.next().await;
+        match req {
+            Ok(Some(req)) => {
+                let executor = executor.clone();
+
+                req.respond(&true).await?;
+                tokio::spawn(async move { executor.kill_backend(&req.value).await });
+            }
+            Ok(None) => return Err(anyhow!("Termination request subscription closed.")),
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "Non-fatal error when listening for termination requests."
+                )
+            }
+        }
+    }
+}
+
 /// Repeatedly publish a status message advertising this drone as available.
-async fn ready_loop(nc: TypedNats, drone_id: DroneId, cluster: String) {
+async fn ready_loop(nc: TypedNats, drone_id: DroneId, cluster: String) -> Result<()> {
     let mut interval = tokio::time::interval(Duration::from_secs(4));
 
     loop {
@@ -132,24 +154,19 @@ pub async fn run_agent(agent_opts: AgentOptions) -> Result<()> {
             cluster: cluster.clone(),
             ip,
         };
-        do_with_retry(
-            || nats.request(&request),
-            30,
-            Duration::from_secs(10),
-        )
-        .await?
+        do_with_retry(|| nats.request(&request), 30, Duration::from_secs(10)).await?
     };
 
     match result {
         DroneConnectResponse::Success { drone_id } => {
-            {
-                let nats = nats.clone();
-                let cluster = cluster.clone();
-                tokio::spawn(ready_loop(nats, drone_id, cluster));
-            }
-
+            let executor = Arc::new(Executor::new(docker, db, nats.clone()));
+            let result = tokio::try_join!(
+                ready_loop(nats.clone(), drone_id, cluster.clone()),
+                listen_for_spawn_requests(drone_id, executor.clone(), nats.clone()),
+                listen_for_termination_requests(executor.clone(), nats.clone())
+            );
             tracing::info!("Listening for spawn requests.");
-            listen_for_spawn_requests(drone_id, docker, nats, db).await
+            result.map(|_| ())
         }
         DroneConnectResponse::NoSuchCluster => Err(anyhow!(
             "The platform server did not recognize the cluster {}",

--- a/drone/src/drone/cert/mod.rs
+++ b/drone/src/drone/cert/mod.rs
@@ -62,12 +62,10 @@ pub async fn get_certificate(
 
         tracing::info!("Requesting TXT record from platform.");
         let result = nats
-            .request(
-                &SetAcmeDnsRecord {
-                    cluster: cluster_domain.to_string(),
-                    value,
-                },
-            )
+            .request(&SetAcmeDnsRecord {
+                cluster: cluster_domain.to_string(),
+                value,
+            })
             .await?;
 
         if !result {

--- a/drone/src/drone/proxy/tls.rs
+++ b/drone/src/drone/proxy/tls.rs
@@ -1,12 +1,12 @@
 //use anyhow::Result;
 use core::future::Future;
 use core::task::Context;
-use std::net::IpAddr;
 use futures::ready;
 use hyper::server::accept::Accept;
 use hyper::server::conn::{AddrIncoming, AddrStream};
 use rustls::ServerConfig;
 use std::io;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Poll;


### PR DESCRIPTION
Draft pr to add backend.:id.terminate. 

I have not yet added the typed-nats checks to ensure the terminate command body refers to the backend_id in the address. (but I don't think that should substantially change anything in what's been written thus far,  just return an error either when `sub.next()` is called or when `msg.value` is accessed 