### PR TITLE
Refactor Typed NATS wrapper

### DIFF
--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
-
-use crate::nats::Subject;
+use crate::nats::{Subject, TypedMessage, SubscribeSubject};
 
 /// A request from the drone to the DNS server telling it to set
 /// a TXT record on the given domain with the given value.
@@ -10,9 +9,16 @@ pub struct SetAcmeDnsRecord {
     pub value: String,
 }
 
-impl SetAcmeDnsRecord {
-    #[must_use]
-    pub fn subject() -> Subject<SetAcmeDnsRecord, bool> {
+impl TypedMessage for SetAcmeDnsRecord {
+    type Response = bool;
+
+    fn subject(&self) -> Subject<Self> {
         Subject::new("acme.set_dns_record".to_string())
+    }
+}
+
+impl SetAcmeDnsRecord {
+    pub fn subscribe_subject() -> SubscribeSubject<Self> {
+        SubscribeSubject::new("acme.set_dns_record".to_string())
     }
 }

--- a/core/src/messages/logging.rs
+++ b/core/src/messages/logging.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use tracing::Level;
-
-use crate::nats::{NoReply, Subject};
+use crate::nats::{NoReply, Subject, TypedMessage};
 
 #[derive(Debug)]
 pub struct SerializableLevel(pub Level);
@@ -42,9 +41,10 @@ pub struct LogMessage {
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-impl LogMessage {
-    #[must_use]
-    pub fn subject(subject_name: &str) -> Subject<LogMessage, NoReply> {
-        Subject::new(subject_name.to_string())
+impl TypedMessage for LogMessage {
+    type Response = NoReply;
+
+    fn subject(&self) -> Subject<LogMessage> {
+        Subject::new("logs.drone".into())
     }
 }

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use dis_spawner::messages::agent::SpawnRequest;
 use dis_spawner::types::BackendId;
+use dis_spawner::types::DroneId;
 use rand::distributions::Alphanumeric;
 use rand::thread_rng;
 use rand::Rng;
@@ -109,6 +110,7 @@ const TEST_IMAGE: &str = "ghcr.io/drifting-in-space/test-image:latest";
 pub fn base_spawn_request() -> SpawnRequest {
     let backend_id = random_backend_id(&test_name());
     SpawnRequest {
+        drone_id: DroneId::new(0),
         image: TEST_IMAGE.into(),
         backend_id: backend_id.clone(),
         max_idle_secs: Duration::from_secs(10),

--- a/dev/tests/cert.rs
+++ b/dev/tests/cert.rs
@@ -29,7 +29,7 @@ struct DummyDnsHandler {
 impl DummyDnsHandler {
     pub async fn new(conn: &TypedNats, expect_domain: &str) -> Result<DummyDnsHandler> {
         let expect_domain = expect_domain.to_owned();
-        let mut dns_sub = conn.subscribe(SetAcmeDnsRecord::subject()).await?;
+        let mut dns_sub = conn.subscribe(SetAcmeDnsRecord::subscribe_subject()).await?;
         let handle = spawn_timeout(10_000, "Should get ACME DNS request.", async move {
             let message = dns_sub.next().await.unwrap().unwrap();
             assert_eq!(expect_domain, message.value.cluster);

--- a/drone/src/drone/agent/executor.rs
+++ b/drone/src/drone/agent/executor.rs
@@ -96,7 +96,6 @@ impl Executor {
 
         self.nc
             .publish(
-                &BackendStateMessage::subject(&spawn_request.backend_id),
                 &BackendStateMessage::new(BackendState::Loading, spawn_request.backend_id.clone()),
             )
             .await
@@ -142,8 +141,8 @@ impl Executor {
                     while let Some(v) = stream.next().await {
                         match v {
                             Ok(v) => {
-                                if let Some(message) = DroneLogMessage::from_log_message(&v) {
-                                    nc.publish(&DroneLogMessage::subject(&backend_id), &message)
+                                if let Some(message) = DroneLogMessage::from_log_message(&backend_id, &v) {
+                                    nc.publish(&message)
                                         .await?;
                                 }
                             }
@@ -174,10 +173,9 @@ impl Executor {
 
                     while let Some(v) = stream.next().await {
                         match v {
-                            Ok(v) => match BackendStatsMessage::from_stats_message(&v) {
+                            Ok(v) => match BackendStatsMessage::from_stats_message(&backend_id, &v) {
                                 Some(message) => {
                                     nc.publish(
-                                        &BackendStatsMessage::subject(&backend_id),
                                         &message,
                                     )
                                     .await?;
@@ -245,7 +243,6 @@ impl Executor {
                         .log_error();
                     self.nc
                         .publish(
-                            &BackendStateMessage::subject(&spawn_request.backend_id),
                             &BackendStateMessage::new(state, spawn_request.backend_id.clone()),
                         )
                         .await

--- a/drone/src/drone/cert/mod.rs
+++ b/drone/src/drone/cert/mod.rs
@@ -63,7 +63,6 @@ pub async fn get_certificate(
         tracing::info!("Requesting TXT record from platform.");
         let result = nats
             .request(
-                &SetAcmeDnsRecord::subject(),
                 &SetAcmeDnsRecord {
                     cluster: cluster_domain.to_string(),
                     value,

--- a/drone/src/drone/mod.rs
+++ b/drone/src/drone/mod.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         } => {
             if let Some(nats) = nats {
                 let nats = nats.connection().await?;
-                tracing_handle.attach_nats(nats, "logs.drone".to_string())?;
+                tracing_handle.attach_nats(nats)?;
             }
 
             let mut futs: Vec<Pin<Box<dyn Future<Output = Result<()>>>>> = vec![];


### PR DESCRIPTION
NATS publish permissioning works at the subject glob level: a user can be given rights to publish to subjects that match a specific glob. If the subject refers to a particular resource (e.g., a particular backend or drone), the ID of that resource can be encoded into the subject to limit who has access to that resource.

A listener who is listening on a wildcard needs to ensure that an incoming message refers to the resource in its subject. Otherwise, a writer with permission to publish to any resource could effectively create messages that refer to *any* subject, and have them treated the same by the wildcard subscriber.

One way to do this is for the subscriber to parse the subject, and then check that the value in the message matches the value in the subject. Another way (which avoids parsing) is to standardize the way subjects are generated for each message type. When a wildcard subscriber receives a message, it regenerates the subject and ensures that it matches the subject over which the message was sent. The advantage of this is that it can be done directly in the typed NATS wrapper, so that it is opaque to subscribers.

This takes the latter approach, implemented as follows:
- A `TypedMessage` trait is introduced. Any message that can be sent to a regular subject (as opposed to a reply inbox) gets this trait. It encodes both a reply type, and a method called `subject` that returns the canonical `Subject` for a particular instance of that type.
- `Subject` and related traits are simplified by referring to a single `TypedMessage` instead of a pair of (request, reply) message types. Because the `TypedMessage` already encodes its reply type, no type safety is lost with this change, but code is simplified.