### PR TITLE
remove default NanoCPUs and use CPU_PERIOD with CPU_QUOTA instead

### DIFF
--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -93,7 +93,7 @@ pub struct LogManagerLogger {
 }
 
 impl LogManagerLogger {
-    fn new(sender: Sender<LogMessage>, channel: String,) -> LogManagerLogger {
+    fn new(sender: Sender<LogMessage>, channel: String) -> LogManagerLogger {
         LogManagerLogger { sender, channel }
     }
 }

--- a/drone/src/drone/agent/docker.rs
+++ b/drone/src/drone/agent/docker.rs
@@ -19,8 +19,11 @@ use tokio_stream::{Stream, StreamExt};
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
 const DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS: u64 = 10;
-const DEFAULT_NANO_CPUS: i64 = (0.2 * 1e9) as i64; //in units of (1e-9 CPU)
 const DEFAULT_CPU_TIME_ULIMIT: i64 = 30; //in minutes
+const DEFAULT_CPU_PERIOD: i64 = (0.1 * 1e6) as i64; //0.1 second, in microseconds
+                                                    //note this 1s is MAX allowed by docker
+const DEFAULT_CPU_QUOTA: i64 = ((DEFAULT_CPU_PERIOD as f64) * 0.97) as i64;
+//allow some leeway in CPU_QUOTA to ensure spawner is not starved of cycles
 
 #[derive(Clone)]
 pub struct DockerInterface {
@@ -307,7 +310,8 @@ impl DockerInterface {
                         .collect(),
                     ),
                     runtime: self.runtime.clone(),
-                    nano_cpus: Some(DEFAULT_NANO_CPUS),
+                    cpu_period: Some(DEFAULT_CPU_PERIOD),
+                    cpu_quota: Some(DEFAULT_CPU_QUOTA),
                     ulimits: Some(vec![ResourcesUlimits {
                         name: Some("cpu".to_string()),
                         soft: Some(DEFAULT_CPU_TIME_ULIMIT),


### PR DESCRIPTION
PROBLEM: The NanoCPUs setting sets shares of 100 milliseconds of
	 CPU time. This is bad for setting defaults, since it leads
	 to degraded performance in bursty workloads.
SOLUTION: Switch to using default CPU_PERIOD of 0.1 seconds with CPU_QUOTA
	  of 97% of that. This ensures breathing room for spawner.
NOTE:   CPU_PERIOD has a max allowed value of 1 second. It'd be nice if
	we could set a longer cpu period. brief investigation suggests
	this is a kernel limit, so maybe a thing that can be improved.