### PR TITLE
Get rid of Subject type (per #132)

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -16,7 +16,8 @@ pub async fn run_scheduler(nats: TypedNats) -> Result<()> {
     let mut spawn_request_sub = nats.subscribe(ScheduleRequest::subscribe_subject()).await?;
 
     let mut status_sub = Box::pin(
-        nats.subscribe_jetstream(DroneStatusMessage::subscribe_subject()).await
+        nats.subscribe_jetstream(DroneStatusMessage::subscribe_subject())
+            .await,
     );
 
     loop {

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -16,11 +16,7 @@ pub async fn run_scheduler(nats: TypedNats) -> Result<()> {
     let mut spawn_request_sub = nats.subscribe(ScheduleRequest::subscribe_subject()).await?;
 
     let mut status_sub = Box::pin(
-        nats.subscribe_jetstream(
-            &DroneStatusMessage::stream_name(),
-            &DroneStatusMessage::subscribe_subject(),
-        )
-        .await,
+        nats.subscribe_jetstream(DroneStatusMessage::subscribe_subject()).await
     );
 
     loop {

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nats::{NoReply, SubscribeSubject, TypedMessage, JetStreamable},
+    nats::{JetStreamable, NoReply, SubscribeSubject, TypedMessage},
     types::{BackendId, DroneId},
 };
 use bollard::{auth::DockerCredentials, container::LogOutput, container::Stats};

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nats::{NoReply, StreamName, Subject, SubscribeSubject, TypedMessage},
+    nats::{NoReply, SubscribeSubject, TypedMessage, JetStreamable},
     types::{BackendId, DroneId},
 };
 use bollard::{auth::DockerCredentials, container::LogOutput, container::Stats};
@@ -27,8 +27,8 @@ pub struct DroneLogMessage {
 impl TypedMessage for DroneLogMessage {
     type Response = NoReply;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("backend.{}.log", self.backend_id.id()))
+    fn subject(&self) -> String {
+        format!("backend.{}.log", self.backend_id.id())
     }
 }
 
@@ -59,10 +59,6 @@ impl DroneLogMessage {
         }
     }
 
-    pub fn stream_name() -> StreamName<Self> {
-        StreamName::new("backend_log".into())
-    }
-
     pub fn subscribe_subject(backend: &BackendId) -> SubscribeSubject<Self> {
         SubscribeSubject::new(format!("backend.{}.log", backend))
     }
@@ -83,8 +79,8 @@ pub struct BackendStatsMessage {
 impl TypedMessage for BackendStatsMessage {
     type Response = NoReply;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("backend.{}.stats", self.backend_id.id()))
+    fn subject(&self) -> String {
+        format!("backend.{}.stats", self.backend_id.id())
     }
 }
 
@@ -149,18 +145,24 @@ pub struct DroneStatusMessage {
 impl TypedMessage for DroneStatusMessage {
     type Response = NoReply;
 
-    fn subject(&self) -> Subject<DroneStatusMessage> {
-        Subject::new(format!("drone.{}.status", self.drone_id.id()))
+    fn subject(&self) -> String {
+        format!("drone.{}.status", self.drone_id.id())
+    }
+}
+
+impl JetStreamable for DroneStatusMessage {
+    fn config() -> async_nats::jetstream::stream::Config {
+        async_nats::jetstream::stream::Config {
+            name: "drone_status".into(),
+            subjects: vec!["drone.*.status".into()],
+            ..async_nats::jetstream::stream::Config::default()
+        }
     }
 }
 
 impl DroneStatusMessage {
     pub fn subscribe_subject() -> SubscribeSubject<DroneStatusMessage> {
         SubscribeSubject::new("drone.*.status".to_string())
-    }
-
-    pub fn stream_name() -> StreamName<Self> {
-        StreamName::new("drone_status".into())
     }
 }
 
@@ -187,8 +189,8 @@ pub enum DroneConnectResponse {
 impl TypedMessage for DroneConnectRequest {
     type Response = DroneConnectResponse;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new("drone.register".to_string())
+    fn subject(&self) -> String {
+        "drone.register".to_string()
     }
 }
 
@@ -228,8 +230,8 @@ pub struct SpawnRequest {
 impl TypedMessage for SpawnRequest {
     type Response = bool;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("drone.{}.spawn", self.drone_id.id()))
+    fn subject(&self) -> String {
+        format!("drone.{}.spawn", self.drone_id.id())
     }
 }
 
@@ -248,8 +250,8 @@ pub struct TerminationRequest {
 impl TypedMessage for TerminationRequest {
     type Response = bool;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("backend.{}.terminate", self.backend_id.id()))
+    fn subject(&self) -> String {
+        format!("backend.{}.terminate", self.backend_id.id())
     }
 }
 
@@ -364,11 +366,21 @@ pub struct BackendStateMessage {
     pub time: DateTime<Utc>,
 }
 
+impl JetStreamable for BackendStateMessage {
+    fn config() -> async_nats::jetstream::stream::Config {
+        async_nats::jetstream::stream::Config {
+            name: "backend_status".into(),
+            subjects: vec!["backend.*.status".into()],
+            ..async_nats::jetstream::stream::Config::default()
+        }
+    }
+}
+
 impl TypedMessage for BackendStateMessage {
     type Response = NoReply;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("backend.{}.status", self.backend.id()))
+    fn subject(&self) -> String {
+        format!("backend.{}.status", self.backend.id())
     }
 }
 
@@ -391,10 +403,5 @@ impl BackendStateMessage {
             backend,
             time: Utc::now(),
         }
-    }
-
-    #[must_use]
-    pub fn stream_name() -> StreamName<BackendStateMessage> {
-        StreamName::new("backend_status".to_string())
     }
 }

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -1,4 +1,4 @@
-use crate::nats::{Subject, SubscribeSubject, TypedMessage};
+use crate::nats::{SubscribeSubject, TypedMessage};
 use serde::{Deserialize, Serialize};
 
 /// A request from the drone to the DNS server telling it to set
@@ -12,8 +12,8 @@ pub struct SetAcmeDnsRecord {
 impl TypedMessage for SetAcmeDnsRecord {
     type Response = bool;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new("acme.set_dns_record".to_string())
+    fn subject(&self) -> String {
+        "acme.set_dns_record".to_string()
     }
 }
 

--- a/core/src/messages/logging.rs
+++ b/core/src/messages/logging.rs
@@ -1,4 +1,4 @@
-use crate::nats::{NoReply, Subject, TypedMessage};
+use crate::nats::{NoReply, TypedMessage};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use core::str::FromStr;
@@ -45,7 +45,7 @@ pub struct LogMessage {
 impl TypedMessage for LogMessage {
     type Response = NoReply;
 
-    fn subject(&self) -> Subject<LogMessage> {
-        Subject::new(format!("logs.{}", self.log_channel))
+    fn subject(&self) -> String {
+        format!("logs.{}", self.log_channel)
     }
 }

--- a/core/src/messages/mod.rs
+++ b/core/src/messages/mod.rs
@@ -9,18 +9,10 @@ pub mod scheduler;
 
 pub async fn create_streams(nats: &TypedNats) -> Result<()> {
     // Ensure that backend status stream exists.
-    nats.add_jetstream_stream(
-        &BackendStateMessage::stream_name(),
-        &BackendStateMessage::wildcard_subject(),
-    )
-    .await?;
+    nats.add_jetstream_stream::<BackendStateMessage>().await?;
 
     // Ensure that drone status stream exists.
-    nats.add_jetstream_stream(
-        &DroneStatusMessage::stream_name(),
-        &DroneStatusMessage::subscribe_subject(),
-    )
-    .await?;
+    nats.add_jetstream_stream::<DroneStatusMessage>().await?;
 
     Ok(())
 }

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nats::{Subject, SubscribeSubject, TypedMessage},
+    nats::{SubscribeSubject, TypedMessage},
     types::{BackendId, DroneId},
 };
 use bollard::auth::DockerCredentials;
@@ -82,8 +82,8 @@ pub enum ScheduleResponse {
 impl TypedMessage for ScheduleRequest {
     type Response = ScheduleResponse;
 
-    fn subject(&self) -> Subject<Self> {
-        Subject::new(format!("cluster.{}.schedule", self.cluster.subject_name()))
+    fn subject(&self) -> String {
+        format!("cluster.{}.schedule", self.cluster.subject_name())
     }
 }
 

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -2,7 +2,6 @@
 //!
 //! These use serde to serialize data to/from JSON over nats into Rust types.
 
-use crate::messages::create_streams;
 use anyhow::{anyhow, Result};
 use async_nats::jetstream::consumer::DeliverPolicy;
 use async_nats::jetstream::stream::Config;
@@ -17,65 +16,19 @@ use std::marker::PhantomData;
 use std::time::Duration;
 use tokio::time::timeout;
 
+use crate::messages::create_streams;
+
 #[derive(Serialize, Deserialize)]
 pub enum NoReply {}
-
-#[derive(Clone)]
-pub struct StreamName<M>
-where
-    M: TypedMessage,
-{
-    stream_name: String,
-    _ph_m: PhantomData<M>,
-}
-
-impl<M> StreamName<M>
-where
-    M: TypedMessage,
-{
-    pub fn new(stream_name: String) -> Self {
-        StreamName {
-            stream_name,
-            _ph_m: PhantomData::default(),
-        }
-    }
-}
 
 pub trait TypedMessage: Serialize + DeserializeOwned {
     type Response: Serialize + DeserializeOwned;
 
-    fn subject(&self) -> Subject<Self>;
+    fn subject(&self) -> String;
 }
 
-#[derive(Clone)]
-pub struct Subject<M>
-where
-    M: TypedMessage,
-{
-    subject: String,
-    _ph_m: PhantomData<M>,
-}
-
-impl<M> Debug for Subject<M>
-where
-    M: TypedMessage,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        self.subject.fmt(f)
-    }
-}
-
-impl<M> Subject<M>
-where
-    M: TypedMessage,
-{
-    #[must_use]
-    pub fn new(subject: String) -> Subject<M> {
-        Subject {
-            subject,
-            _ph_m: PhantomData::default(),
-        }
-    }
+pub trait JetStreamable: TypedMessage {
+    fn config() -> Config;
 }
 
 impl<M> Debug for SubscribeSubject<M>
@@ -105,49 +58,6 @@ where
             subject,
             _ph_m: PhantomData::default(),
         }
-    }
-}
-
-pub trait Subscribable<M>
-where
-    M: TypedMessage,
-{
-    fn subject(&self) -> &str;
-}
-
-impl<M> Subscribable<M> for Subject<M>
-where
-    M: TypedMessage,
-{
-    fn subject(&self) -> &str {
-        &self.subject
-    }
-}
-
-impl<M> Subscribable<M> for SubscribeSubject<M>
-where
-    M: TypedMessage,
-{
-    fn subject(&self) -> &str {
-        &self.subject
-    }
-}
-
-impl<M> Subscribable<M> for &Subject<M>
-where
-    M: TypedMessage,
-{
-    fn subject(&self) -> &str {
-        &self.subject
-    }
-}
-
-impl<M> Subscribable<M> for &SubscribeSubject<M>
-where
-    M: TypedMessage,
-{
-    fn subject(&self) -> &str {
-        &self.subject
     }
 }
 
@@ -283,7 +193,7 @@ impl TypedNats {
         let subscription = self.nc.subscribe(inbox.clone()).await.to_anyhow()?;
         self.nc
             .publish_with_reply(
-                message.subject().subject().to_string(),
+                message.subject(),
                 inbox,
                 Bytes::from(serde_json::to_vec(&message)?),
             )
@@ -296,21 +206,13 @@ impl TypedNats {
         })
     }
 
-    pub async fn add_jetstream_stream<P, T>(
-        &self,
-        stream_name: &StreamName<T>,
-        subject: &P,
+    pub async fn add_jetstream_stream<T: JetStreamable>(
+        &self
     ) -> Result<()>
-    where
-        P: Subscribable<T>,
-        T: TypedMessage,
     {
+        let config = T::config();
         self.jetstream
-            .get_or_create_stream(Config {
-                name: stream_name.stream_name.to_string(),
-                subjects: vec![subject.subject().to_string()],
-                ..Config::default()
-            })
+            .get_or_create_stream(config)
             .await
             .to_anyhow()?;
 
@@ -333,7 +235,7 @@ impl TypedNats {
         TypedNats { nc, jetstream }
     }
 
-    pub async fn get_latest<T>(&self, subject: &Subject<T>, stream_name: &str) -> Result<Option<T>>
+    pub async fn get_latest<T>(&self, subject: &SubscribeSubject<T>, stream_name: &str) -> Result<Option<T>>
     where
         T: TypedMessage<Response = NoReply>,
     {
@@ -342,7 +244,7 @@ impl TypedNats {
         let consumer = stream
             .create_consumer(async_nats::jetstream::consumer::pull::Config {
                 deliver_policy: DeliverPolicy::Last,
-                filter_subject: subject.subject().to_string(),
+                filter_subject: subject.subject.clone(),
                 ..async_nats::jetstream::consumer::pull::Config::default()
             })
             .await
@@ -361,18 +263,15 @@ impl TypedNats {
         Ok(Some(serde_json::from_slice(&result.payload)?))
     }
 
-    pub async fn subscribe_jetstream<P, T>(
+    pub async fn subscribe_jetstream<T: JetStreamable>(
         &self,
-        stream_name: &StreamName<T>,
-        subject: &P,
+        subject: SubscribeSubject<T>
     ) -> impl Stream<Item = T>
-    where
-        P: Subscribable<T>,
-        T: TypedMessage + Send + 'static,
     {
         let jetstream = self.jetstream.clone();
-        let subject = subject.subject().to_string();
-        let stream_name = stream_name.stream_name.to_string();
+        let subject = subject.subject.to_string();
+        let config = T::config();
+        let stream_name = config.name;
 
         let stream = stream!({
             let stream = jetstream.get_stream(stream_name).await.unwrap();
@@ -407,7 +306,7 @@ impl TypedNats {
     {
         self.nc
             .publish(
-                value.subject().subject.clone(),
+                value.subject().clone(),
                 Bytes::from(serde_json::to_vec(value)?),
             )
             .await?;
@@ -421,7 +320,7 @@ impl TypedNats {
         let result = self
             .nc
             .request(
-                value.subject().subject,
+                value.subject(),
                 Bytes::from(serde_json::to_vec(value)?),
             )
             .await
@@ -431,14 +330,13 @@ impl TypedNats {
         Ok(value)
     }
 
-    pub async fn subscribe<P, T>(&self, subject: P) -> Result<TypedSubscription<T>>
+    pub async fn subscribe<T>(&self, subject: SubscribeSubject<T>) -> Result<TypedSubscription<T>>
     where
-        P: Subscribable<T>,
         T: TypedMessage,
     {
         let subscription = self
             .nc
-            .subscribe(subject.subject().to_string())
+            .subscribe(subject.subject)
             .await
             .to_anyhow()?;
         Ok(TypedSubscription::new(subscription, self.nc.clone()))

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -206,10 +206,7 @@ impl TypedNats {
         })
     }
 
-    pub async fn add_jetstream_stream<T: JetStreamable>(
-        &self
-    ) -> Result<()>
-    {
+    pub async fn add_jetstream_stream<T: JetStreamable>(&self) -> Result<()> {
         let config = T::config();
         self.jetstream
             .get_or_create_stream(config)
@@ -235,7 +232,11 @@ impl TypedNats {
         TypedNats { nc, jetstream }
     }
 
-    pub async fn get_latest<T>(&self, subject: &SubscribeSubject<T>, stream_name: &str) -> Result<Option<T>>
+    pub async fn get_latest<T>(
+        &self,
+        subject: &SubscribeSubject<T>,
+        stream_name: &str,
+    ) -> Result<Option<T>>
     where
         T: TypedMessage<Response = NoReply>,
     {
@@ -265,9 +266,8 @@ impl TypedNats {
 
     pub async fn subscribe_jetstream<T: JetStreamable>(
         &self,
-        subject: SubscribeSubject<T>
-    ) -> impl Stream<Item = T>
-    {
+        subject: SubscribeSubject<T>,
+    ) -> impl Stream<Item = T> {
         let jetstream = self.jetstream.clone();
         let subject = subject.subject.to_string();
         let config = T::config();
@@ -319,10 +319,7 @@ impl TypedNats {
     {
         let result = self
             .nc
-            .request(
-                value.subject(),
-                Bytes::from(serde_json::to_vec(value)?),
-            )
+            .request(value.subject(), Bytes::from(serde_json::to_vec(value)?))
             .await
             .to_anyhow()?;
 
@@ -334,11 +331,7 @@ impl TypedNats {
     where
         T: TypedMessage,
     {
-        let subscription = self
-            .nc
-            .subscribe(subject.subject)
-            .await
-            .to_anyhow()?;
+        let subscription = self.nc.subscribe(subject.subject).await.to_anyhow()?;
         Ok(TypedSubscription::new(subscription, self.nc.clone()))
     }
 }

--- a/drone/src/drone/agent/mod.rs
+++ b/drone/src/drone/agent/mod.rs
@@ -69,7 +69,7 @@ async fn listen_for_spawn_requests(
     nats: TypedNats,
 ) -> Result<()> {
     let mut sub = nats
-        .subscribe(&SpawnRequest::subscribe_subject(drone_id))
+        .subscribe(SpawnRequest::subscribe_subject(drone_id))
         .await?;
     executor.resume_backends().await?;
     tracing::info!("Listening for spawn requests.");


### PR DESCRIPTION
This is the first of several refactors under #132 to make the NATS wrapper nicer/safer to work with.

**Remove `Subject`**: `Subject` was only used to describe subjects to publish to, and `SubscribeSubject` was used for subscriptions. It's still useful to have a typed handle to a (possibly wildcard) subject to use for subscriptions, but we recently added a rule that a message should always be sent to a subject deterministically derived from the message itself. That means we no longer have a need for a typed `Subject`; when we want to send a message we just pass the message itself.

**Remove `StreamName`**: `StreamName` was used as a typed handle to the JetStream stream associated with an object. Rather than passing this handle around, we implement a `JetStreamable` trait instead that returns a config. This has the additional advantage of allowing us to add per-stream configuration rules.