### PR TITLE
Update deps + misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,21 +70,22 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "async-nats"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f3d93ad98fe0aed0236fd887b5f26b26edd7d40f3f3d2cd0fc5dc23cf1a7c3"
+checksum = "e2cc9bc81803b5d77fb0a7c321c0fc9963436562361f158712f8161805033a46"
 dependencies = [
  "base64-url",
  "bytes",
  "futures",
  "http",
  "itoa",
+ "lazy_static",
  "nkeys",
  "nuid",
  "once_cell",
@@ -100,28 +101,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tracing",
  "url",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -281,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -298,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -587,16 +568,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
- "async-stream",
  "bollard",
  "bytes",
  "chrono",
  "dashmap",
- "futures",
  "serde",
  "serde_json",
  "serde_with 2.0.0",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-stackdriver",
  "tracing-subscriber",
@@ -776,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -791,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -801,15 +781,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -829,15 +809,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -846,21 +826,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1314,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0-pre.16"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530f6314d6904508082f4ea424a0275cf62d341e118b313663f266429cb19693"
+checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -2376,9 +2356,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
  "bytes",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.62"
+anyhow = "1.0.64"
 chrono = "0.4.22"
-clap = { version = "3.2.17", features = ["derive"] }
+clap = { version = "3.2.20", features = ["derive"] }
 dashmap = "5.3.4"
 dis-spawner = {path = "../core"}
 rand = "0.8.5"
-tokio = { version = "1.20.1", features = ["macros", "rt"] }
+tokio = { version = "1.21.0", features = ["macros", "rt"] }
 tokio-stream = "0.1.9"
 tracing = "0.1.36"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,17 +5,16 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.61"
-async-nats = "0.18.0"
-async-stream = "0.3.3"
+async-nats = "0.19.0"
 bollard = "0.13.0"
 bytes = "1.2.1"
 chrono = { version = "0.4.22", features = ["serde"] }
 dashmap = "5.4.0"
-futures = "0.3.23"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 serde_with = "2.0.0"
 tokio = "1.20.1"
+tokio-stream = "0.1.9"
 tracing = "0.1.36"
 tracing-stackdriver = "0.5.0"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -1,4 +1,7 @@
-use crate::{nats::{SubscribeSubject, TypedMessage}, types::ClusterName};
+use crate::{
+    nats::{SubscribeSubject, TypedMessage},
+    types::ClusterName,
+};
 use serde::{Deserialize, Serialize};
 
 /// A request from the drone to the DNS server telling it to set

--- a/core/src/retry.rs
+++ b/core/src/retry.rs
@@ -1,5 +1,4 @@
-use futures::Future;
-use std::{fmt::Debug, time::Duration};
+use std::{fmt::Debug, future::Future, time::Duration};
 
 /// Run a closure until the future it returns resolves to an Ok value.
 ///

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, str::FromStr, convert::Infallible};
+use std::{convert::Infallible, fmt::Display, str::FromStr};
 
 const RESOURCE_PREFIX: &str = "spawner-";
 

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.62"
-async-nats = "0.18.0"
+async-nats = "0.19.0"
 bollard = "0.13.0"
 chrono = "0.4.22"
 dis-spawner = {path = "../core"}
 dis-spawner-drone = {path = "../drone"}
 dis-spawner-controller = {path = "../controller"}
-futures = "0.3.23"
+futures = "0.3.24"
 http = "0.2.8"
 hyper = "0.14.20"
 integration-test = { path = "./integration-test" }

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -32,7 +32,7 @@ const CLUSTER_DOMAIN: &str = "spawner.test";
 
 struct Agent {
     #[allow(unused)]
-    agent_guard: LivenessGuard,
+    agent_guard: LivenessGuard<Result<()>>,
     pub ip: Ipv4Addr,
     pub db: DroneDatabase,
 }

--- a/dev/tests/cert.rs
+++ b/dev/tests/cert.rs
@@ -5,7 +5,8 @@ use dev::{
     timeout::{spawn_timeout, timeout},
 };
 use dis_spawner::{
-    messages::cert::SetAcmeDnsRecord, nats::TypedNats, nats_connection::NatsConnection, types::ClusterName
+    messages::cert::SetAcmeDnsRecord, nats::TypedNats, nats_connection::NatsConnection,
+    types::ClusterName,
 };
 use dis_spawner_drone::{
     drone::cli::{CertOptions, EabKeypair},

--- a/dev/tests/proxy.rs
+++ b/dev/tests/proxy.rs
@@ -23,7 +23,7 @@ const CLUSTER: &str = "spawner.test";
 
 struct Proxy {
     #[allow(unused)]
-    guard: LivenessGuard,
+    guard: LivenessGuard<Result<()>>,
     //ip: Ipv4Addr,
     bind_address: SocketAddr,
     certs: SelfSignedCert,

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -76,6 +76,7 @@ async fn no_drone_available() -> Result<()> {
     sleep(Duration::from_millis(100)).await;
 
     let request = base_scheduler_request();
+    tracing::info!("Making spawn request.");
     let result = timeout(
         1_000,
         "Schedule request should be responded.",

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -12,10 +12,10 @@ chrono = { version = "0.4.21", features = ["serde"] }
 clap = { version = "3.2.2", features = ["derive"] }
 dashmap = "5.3.4"
 dis-spawner = {path = "../core"}
-futures = "0.3.21"
+futures = "0.3.24"
 http = "0.2.7"
 hyper = { version = "0.14.19", features = ["server", "client", "http1", "http2", "tcp"] }
-notify = "5.0.0-pre.15"
+notify = "5.0.0"
 openssl = "0.10.40"
 reqwest = { version = "0.11.11", features=["native-tls"] }
 rustls = "0.20.6"

--- a/drone/src/drone/agent/docker.rs
+++ b/drone/src/drone/agent/docker.rs
@@ -8,7 +8,6 @@ use bollard::{
     },
     image::CreateImageOptions,
     models::{EventMessage, HostConfig, PortBinding},
-    service::ResourcesUlimits,
     system::EventsOptions,
     Docker, API_DEFAULT_VERSION,
 };
@@ -19,10 +18,10 @@ use tokio_stream::{Stream, StreamExt};
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
 const DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS: u64 = 10;
-const DEFAULT_CPU_TIME_ULIMIT: i64 = 30; //in minutes
-const DEFAULT_CPU_PERIOD: i64 = (0.1 * 1e6) as i64; //0.1 second, in microseconds
-                                                    //note this 1s is MAX allowed by docker
-const DEFAULT_CPU_QUOTA: i64 = ((DEFAULT_CPU_PERIOD as f64) * 0.97) as i64;
+// const DEFAULT_CPU_TIME_ULIMIT: i64 = 30; //in minutes
+// const DEFAULT_CPU_PERIOD: i64 = (0.1 * 1e6) as i64; //0.1 second, in microseconds
+//                                                     //note this 1s is MAX allowed by docker
+// const DEFAULT_CPU_QUOTA: i64 = ((DEFAULT_CPU_PERIOD as f64) * 0.97) as i64;
 //allow some leeway in CPU_QUOTA to ensure spawner is not starved of cycles
 
 #[derive(Clone)]


### PR DESCRIPTION
- Update dependencies, including to `async-nats` 0.19.0.
- Remove panics from `subscribe_jetstream` (#141) 
- Rewrote `LivenessGuard` in the test framework to panic immediately if the future it's guarding terminates.
- Remove a few dependencies made unnecessary by the rewrite of `JetstreamSubscription`.

This is ready for review, but will have some conflicts with #149. Given that this should be an easier review, I'd like to get it in first and rebase 149 over it.