### PR TITLE
Abhi/fix ulimits

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -6,7 +6,7 @@ use bollard::{auth::DockerCredentials, container::LogOutput, container::Stats};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use serde_with::{DurationMicroSeconds, DurationSeconds};
+use serde_with::DurationSeconds;
 use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -243,7 +243,8 @@ pub struct SpawnRequest {
     pub credentials: Option<DockerCredentials>,
 
     /// Resource limits
-    pub resource_limits: Option<ResourceLimits>,
+    #[serde(default = "ResourceLimits::default")]
+    pub resource_limits: ResourceLimits,
 }
 
 // eventually, this will be generic over executors
@@ -252,24 +253,23 @@ pub struct SpawnRequest {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ResourceLimits {
     /// period of cpu time, serializes as microseconds
-    #[serde_as(as = "DurationMicroSeconds")]
-    pub cpu_period: Duration,
+    #[serde_as(as = "Option<DurationSeconds>")]
+    pub cpu_period: Option<Duration>,
 
     /// proportion of period used by container
-    pub cpu_period_percent: u8,
+    pub cpu_period_percent: Option<u8>,
 
     /// total cpu time allocated to container    
-
-    #[serde_as(as = "DurationSeconds")]
-    pub cpu_time_limit: Duration,
+    #[serde_as(as = "Option<DurationSeconds>")]
+    pub cpu_time_limit: Option<Duration>,
 }
 
 impl Default for ResourceLimits {
     fn default() -> ResourceLimits {
         ResourceLimits {
-            cpu_period: Duration::from_millis(100),
-            cpu_period_percent: 100,
-            cpu_time_limit: Duration::from_secs(30 * 60),
+            cpu_period: None,
+            cpu_period_percent: None,
+            cpu_time_limit: None,
         }
     }
 }

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -264,6 +264,16 @@ pub struct ResourceLimits {
     pub cpu_time_limit: Duration,
 }
 
+impl Default for ResourceLimits {
+    fn default() -> ResourceLimits {
+        ResourceLimits {
+            cpu_period: Duration::from_millis(100),
+            cpu_period_percent: 100,
+            cpu_time_limit: Duration::from_secs(30),
+        }
+    }
+}
+
 impl TypedMessage for SpawnRequest {
     type Response = bool;
 

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -6,7 +6,7 @@ use bollard::{auth::DockerCredentials, container::LogOutput, container::Stats};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use serde_with::DurationSeconds;
+use serde_with::{DurationMicroSeconds, DurationSeconds};
 use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -241,6 +241,27 @@ pub struct SpawnRequest {
 
     /// Credentials used to fetch the image.
     pub credentials: Option<DockerCredentials>,
+
+    /// Resource limits
+    pub resource_limits: Option<ResourceLimits>,
+}
+
+// eventually, this will be generic over executors
+// currently only applies to docker
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ResourceLimits {
+    /// period of cpu time, serializes as microseconds
+    #[serde_as(as = "DurationMicroSeconds")]
+    pub cpu_period: Duration,
+
+    /// proportion of period used by container
+    pub cpu_period_percent: u8,
+
+    /// total cpu time allocated to container    
+
+    #[serde_as(as = "DurationSeconds")]
+    pub cpu_time_limit: Duration,
 }
 
 impl TypedMessage for SpawnRequest {

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -269,7 +269,7 @@ impl Default for ResourceLimits {
         ResourceLimits {
             cpu_period: Duration::from_millis(100),
             cpu_period_percent: 100,
-            cpu_time_limit: Duration::from_secs(30),
+            cpu_time_limit: Duration::from_secs(30 * 60),
         }
     }
 }

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -45,7 +45,7 @@ impl ScheduleRequest {
             env: self.env.clone(),
             metadata: self.metadata.clone(),
             credentials: self.credentials.clone(),
-            resource_limits: None,
+            resource_limits: Default::default(),
         }
     }
 }

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -45,6 +45,7 @@ impl ScheduleRequest {
             env: self.env.clone(),
             metadata: self.metadata.clone(),
             credentials: self.credentials.clone(),
+            resource_limits: None,
         }
     }
 }

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -118,7 +118,7 @@ pub fn base_spawn_request() -> SpawnRequest {
         env: vec![("PORT".into(), "8080".into())].into_iter().collect(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),
         credentials: None,
-        resource_limits: None,
+        resource_limits: Default::default(),
     }
 }
 

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -118,6 +118,7 @@ pub fn base_spawn_request() -> SpawnRequest {
         env: vec![("PORT".into(), "8080".into())].into_iter().collect(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),
         credentials: None,
+        resource_limits: None,
     }
 }
 

--- a/drone/src/drone/agent/docker.rs
+++ b/drone/src/drone/agent/docker.rs
@@ -7,7 +7,7 @@ use bollard::{
         StatsOptions, StopContainerOptions,
     },
     image::CreateImageOptions,
-    models::{EventMessage, HostConfig, PortBinding},
+    models::{EventMessage, HostConfig, PortBinding, ResourcesUlimits},
     system::EventsOptions,
     Docker, API_DEFAULT_VERSION,
 };
@@ -18,10 +18,10 @@ use tokio_stream::{Stream, StreamExt};
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
 const DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS: u64 = 10;
-// const DEFAULT_CPU_TIME_ULIMIT: i64 = 30; //in minutes
-// const DEFAULT_CPU_PERIOD: i64 = (0.1 * 1e6) as i64; //0.1 second, in microseconds
-//                                                     //note this 1s is MAX allowed by docker
-// const DEFAULT_CPU_QUOTA: i64 = ((DEFAULT_CPU_PERIOD as f64) * 0.97) as i64;
+const DEFAULT_CPU_TIME_ULIMIT: i64 = 30; //in minutes
+const DEFAULT_CPU_PERIOD: i64 = (0.1 * 1e6) as i64; //0.1 second, in microseconds
+                                                    //                                                     //note this 1s is MAX allowed by docker
+const DEFAULT_CPU_QUOTA: i64 = ((DEFAULT_CPU_PERIOD as f64) * 0.97) as i64;
 //allow some leeway in CPU_QUOTA to ensure spawner is not starved of cycles
 
 #[derive(Clone)]
@@ -309,13 +309,13 @@ impl DockerInterface {
                         .collect(),
                     ),
                     runtime: self.runtime.clone(),
-                    // cpu_period: Some(DEFAULT_CPU_PERIOD),
-                    // cpu_quota: Some(DEFAULT_CPU_QUOTA),
-                    // ulimits: Some(vec![ResourcesUlimits {
-                    //     name: Some("cpu".to_string()),
-                    //     soft: Some(DEFAULT_CPU_TIME_ULIMIT),
-                    //     hard: Some(DEFAULT_CPU_TIME_ULIMIT),
-                    // }]),
+                    cpu_period: Some(DEFAULT_CPU_PERIOD),
+                    cpu_quota: Some(DEFAULT_CPU_QUOTA),
+                    ulimits: Some(vec![ResourcesUlimits {
+                        name: Some("cpu".to_string()),
+                        soft: Some(DEFAULT_CPU_TIME_ULIMIT),
+                        hard: Some(DEFAULT_CPU_TIME_ULIMIT),
+                    }]),
                     ..HostConfig::default()
                 }),
                 ..Config::default()

--- a/drone/src/drone/agent/docker.rs
+++ b/drone/src/drone/agent/docker.rs
@@ -328,16 +328,14 @@ impl DockerInterface {
                             cpu_period
                                 .saturating_mul(cpu_period_percent as u32)
                                 .checked_div(100)
-                                .and_then(
-                                    |cpu_period_time| Some(cpu_period_time.as_micros() as i64),
-                                )
+                                .map(|cpu_period_time| cpu_period_time.as_micros() as i64)
                         }),
-                    ulimits: resource_limits.cpu_time_limit.and_then(|cpu_time_limit| {
-                        Some(vec![ResourcesUlimits {
+                    ulimits: resource_limits.cpu_time_limit.map(|cpu_time_limit| {
+                        vec![ResourcesUlimits {
                             name: Some("cpu".to_string()),
                             soft: Some(cpu_time_limit.as_minutes() as i64),
                             hard: Some(cpu_time_limit.as_minutes() as i64),
-                        }])
+                        }]
                     }),
                     ..HostConfig::default()
                 }),

--- a/drone/src/drone/agent/executor.rs
+++ b/drone/src/drone/agent/executor.rs
@@ -291,7 +291,7 @@ impl Executor {
                         &backend_id,
                         &spawn_request.image,
                         &spawn_request.env,
-                        &spawn_request.resource_limits.clone().unwrap_or_default(),
+                        &spawn_request.resource_limits,
                     )
                     .await?;
                 tracing::info!(%backend_id, "Container is running.");

--- a/drone/src/drone/agent/executor.rs
+++ b/drone/src/drone/agent/executor.rs
@@ -287,7 +287,12 @@ impl Executor {
 
                 let backend_id = spawn_request.backend_id.to_resource_name();
                 self.docker
-                    .run_container(&backend_id, &spawn_request.image, &spawn_request.env)
+                    .run_container(
+                        &backend_id,
+                        &spawn_request.image,
+                        &spawn_request.env,
+                        &spawn_request.resource_limits.clone().unwrap_or_default(),
+                    )
                     .await?;
                 tracing::info!(%backend_id, "Container is running.");
 


### PR DESCRIPTION
This PR brings back the cpu ulimit, cpu_period, and cpu_quota.
To do so, I've added an optional ResourceLimits field to SpawnRequest of the form:
```rust
ResourceLimits {
    cpu_period: Duration,
    cpu_period_percent: u8,
    cpu_time_limit: Duration
}
```
(The defaults for this field are a 30 min ulimit and a 100 ms cpu_period with 100% cpu_period_percent)

This PR is still in draft, I'll add tests tomorrow, and run manually on staging to ensure no regressions re: jupyterlab etc. just wanted thoughts on the message schema.
