### PR TITLE
Add scheduler tests and implement per-cluster scheduling

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn run_scheduler(nats: TypedNats) -> NeverResult {
                 tracing::info!(?spawn_request, "Got spawn request");
                 match spawn_request {
                     Ok(Some(spawn_request)) => {
-                        let result = match scheduler.schedule() {
+                        let result = match scheduler.schedule(&spawn_request.value.cluster, Utc::now()) {
                             Ok(drone_id) => {
                                 match nats.request(&spawn_request.value.schedule(drone_id)).await {
                                     Ok(false) | Err(_) => ScheduleResponse::NoDroneAvailable,

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -1,15 +1,15 @@
 use chrono::{DateTime, Duration, Utc};
 use dashmap::DashMap;
-use dis_spawner::{messages::agent::DroneStatusMessage, types::DroneId};
+use dis_spawner::{messages::agent::DroneStatusMessage, types::{DroneId, ClusterName}};
 use rand::{seq::SliceRandom, thread_rng};
 use std::{error::Error, fmt::Display};
 
 #[derive(Default)]
 pub struct Scheduler {
-    last_status: DashMap<DroneId, DateTime<Utc>>,
+    last_status: DashMap<ClusterName, DashMap<DroneId, DateTime<Utc>>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SchedulerError {
     NoDroneAvailable,
 }
@@ -24,16 +24,20 @@ impl Error for SchedulerError {}
 
 impl Scheduler {
     pub fn update_status(&self, timestamp: DateTime<Utc>, status: &DroneStatusMessage) {
-        self.last_status.insert(status.drone_id, timestamp);
+        self.last_status.entry(status.cluster.clone()).or_default().insert(status.drone_id, timestamp);
     }
 
-    pub fn schedule(&self) -> Result<DroneId, SchedulerError> {
+    pub fn schedule(&self, cluster: &ClusterName, current_timestamp: DateTime<Utc>) -> Result<DroneId, SchedulerError> {
         // TODO: this is a dumb placeholder scheduler.
 
-        let threshold_time = Utc::now().checked_sub_signed(Duration::seconds(5)).unwrap();
+        let threshold_time = current_timestamp
+            .checked_sub_signed(Duration::seconds(5))
+            .unwrap();
 
         let drone_ids: Vec<DroneId> = self
             .last_status
+            .get(cluster)
+            .ok_or(SchedulerError::NoDroneAvailable)?
             .iter()
             .filter(|d| d.value() > &threshold_time)
             .map(|d| *d.key())
@@ -43,5 +47,81 @@ impl Scheduler {
             .choose(&mut thread_rng())
             .cloned()
             .ok_or(SchedulerError::NoDroneAvailable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(date: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(date).unwrap().into()
+    }
+
+    #[test]
+    fn test_no_drones() {
+        let scheduler = Scheduler::default();
+        let timestamp = date("2020-01-01T05:00:00+00:00");
+        assert_eq!(
+            Err(SchedulerError::NoDroneAvailable),
+            scheduler.schedule(&ClusterName::new("mycluster.test"), timestamp)
+        );
+    }
+
+    #[test]
+    fn test_one_drone() {
+        let scheduler = Scheduler::default();
+
+        scheduler.update_status(
+            date("2020-01-01T05:00:00+00:00"),
+            &DroneStatusMessage {
+                drone_id: DroneId::new(3),
+                cluster: ClusterName::new("mycluster.test"),
+                capacity: 100,
+            },
+        );
+
+        assert_eq!(
+            Ok(DroneId::new(3)),
+            scheduler.schedule(&ClusterName::new("mycluster.test"), date("2020-01-01T05:00:03+00:00"))
+        );
+    }
+
+    #[test]
+    fn test_one_drone_wrong_cluster() {
+        let scheduler = Scheduler::default();
+
+        scheduler.update_status(
+            date("2020-01-01T05:00:00+00:00"),
+            &DroneStatusMessage {
+                drone_id: DroneId::new(3),
+                cluster: ClusterName::new("mycluster1.test"),
+                capacity: 100,
+            },
+        );
+
+        assert_eq!(
+            Err(SchedulerError::NoDroneAvailable),
+            scheduler.schedule(&ClusterName::new("mycluster2.test"), date("2020-01-01T05:00:03+00:00"))
+        );
+    }
+
+    #[test]
+    fn test_one_drone_expired() {
+        let scheduler = Scheduler::default();
+
+        scheduler.update_status(
+            date("2020-01-01T05:00:00+00:00"),
+            &DroneStatusMessage {
+                drone_id: DroneId::new(3),
+                cluster: ClusterName::new("mycluster.test"),
+                capacity: 100,
+            },
+        );
+
+        assert_eq!(
+            Err(SchedulerError::NoDroneAvailable),
+            scheduler.schedule(&ClusterName::new("mycluster.test"), date("2020-01-01T05:00:09+00:00"))
+        );
     }
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -56,7 +56,7 @@ impl BackendId {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClusterName(String);
 
 impl FromStr for ClusterName {


### PR DESCRIPTION
This is a pretty straightforward PR; highlights:
- `Scheduler` no longer accesses system time directly; takes it as an argument for ease of unit testing
- `Scheduler` now operates on a per-cluster basis.
- Added some unit tests.

Fixes #146