### PR TITLE
Use jetstream for status message

### DIFF
--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -100,7 +100,7 @@ async fn ready_loop(nc: TypedNats, drone_id: &DroneId, cluster: ClusterName) -> 
     let mut interval = tokio::time::interval(Duration::from_secs(4));
 
     loop {
-        nc.publish(&DroneStatusMessage {
+        nc.publish_jetstream(&DroneStatusMessage {
             drone_id: drone_id.clone(),
             capacity: 100,
             cluster: cluster.clone(),


### PR DESCRIPTION
This uses jetstream for sending node status messages, which means that an error will be logged if there is an issue with the stream.

Related: #168 