### PR TITLE
Limit stream to one message per drone

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -170,6 +170,7 @@ impl JetStreamable for DroneStatusMessage {
         async_nats::jetstream::stream::Config {
             name: Self::stream_name().into(),
             subjects: vec!["drone.*.status".into()],
+            max_messages_per_subject: 1,
             ..async_nats::jetstream::stream::Config::default()
         }
     }


### PR DESCRIPTION
Previously, we would retain all drone status messages in jetstream and replay them. Now we don't.