### PR TITLE
move from streaming stats api to polling

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -137,8 +137,9 @@ impl BackendStatsMessage {
         //      is what proportion of total cpu resource is consumed, and not knowing
         //      the top bound makes that impossible
         let cpu_use_percent = (cpu_delta as f64 / sys_cpu_delta) * 100.0;
-        //disk
-        //TODO: stream https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect
+
+        //TODO: implement disk stats from
+        //      stream at https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect
 
         BackendStatsMessage {
             backend_id: backend_id.clone(),

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -104,7 +104,7 @@ impl BackendStatsMessage {
 }
 
 impl BackendStatsMessage {
-    pub fn from_stats_message(
+    pub fn from_stats_messages(
         backend_id: &BackendId,
         prev_stats_message: &Stats,
         cur_stats_message: &Stats,

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -107,10 +107,12 @@ impl BackendStatsMessage {
         backend_id: &BackendId,
         prev_stats_message: &Stats,
         cur_stats_message: &Stats,
-    ) -> Option<BackendStatsMessage> {
+    ) -> BackendStatsMessage {
         // based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
 
         //memory
+        tracing::warn!(?prev_stats_message, "yeet");
+        tracing::warn!(?cur_stats_message, "deet");
         let mem_naive_usage = cur_stats_message.memory_stats.usage.unwrap_or_default();
         let mem_available = cur_stats_message.memory_stats.limit.unwrap_or(u64::MAX);
         let mem_stats = cur_stats_message.memory_stats.stats;
@@ -130,9 +132,6 @@ impl BackendStatsMessage {
         let precpu_stats = &prev_stats_message.cpu_stats;
         //NOTE: total_usage gives clock cycles, this is monotonically increasing
         let cpu_delta = cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage;
-        if cpu_delta == 0 {
-            return None;
-        }
         let sys_cpu_delta = (cpu_stats.system_cpu_usage.unwrap_or_default() as f64)
             - (precpu_stats.system_cpu_usage.unwrap_or_default() as f64);
         //NOTE: we deviate from docker's formula here by not multiplying by num_cpus
@@ -143,11 +142,11 @@ impl BackendStatsMessage {
         //disk
         //TODO: stream https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect
 
-        Some(BackendStatsMessage {
+        BackendStatsMessage {
             backend_id: backend_id.clone(),
             cpu_use_percent,
             mem_use_percent,
-        })
+        }
     }
 }
 

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -105,14 +105,15 @@ impl BackendStatsMessage {
 impl BackendStatsMessage {
     pub fn from_stats_message(
         backend_id: &BackendId,
-        stats_message: &Stats,
+        prev_stats_message: &Stats,
+        cur_stats_message: &Stats,
     ) -> Option<BackendStatsMessage> {
         // based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
 
         //memory
-        let mem_naive_usage = stats_message.memory_stats.usage.unwrap_or_default();
-        let mem_available = stats_message.memory_stats.limit.unwrap_or(u64::MAX);
-        let mem_stats = stats_message.memory_stats.stats;
+        let mem_naive_usage = cur_stats_message.memory_stats.usage.unwrap_or_default();
+        let mem_available = cur_stats_message.memory_stats.limit.unwrap_or(u64::MAX);
+        let mem_stats = cur_stats_message.memory_stats.stats;
         let cache_mem = match mem_stats {
             Some(stats) => match stats {
                 bollard::container::MemoryStatsStats::V1(stats) => stats.cache,
@@ -125,8 +126,8 @@ impl BackendStatsMessage {
 
         //REF: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
         //cpu
-        let cpu_stats = &stats_message.cpu_stats;
-        let precpu_stats = &stats_message.precpu_stats;
+        let cpu_stats = &cur_stats_message.cpu_stats;
+        let precpu_stats = &prev_stats_message.cpu_stats;
         //NOTE: total_usage gives clock cycles, this is monotonically increasing
         let cpu_delta = cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage;
         if cpu_delta == 0 {

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -111,8 +111,6 @@ impl BackendStatsMessage {
         // based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
 
         //memory
-        tracing::warn!(?prev_stats_message, "yeet");
-        tracing::warn!(?cur_stats_message, "deet");
         let mem_naive_usage = cur_stats_message.memory_stats.usage.unwrap_or_default();
         let mem_available = cur_stats_message.memory_stats.limit.unwrap_or(u64::MAX);
         let mem_stats = cur_stats_message.memory_stats.stats;

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -314,8 +314,8 @@ async fn stats_are_acquired() -> Result<()> {
     )
     .await?
     .unwrap();
-    assert!(stat.value.cpu_use_percent > 0.);
-    assert!(stat.value.mem_use_percent > 0.);
+    assert!(stat.value.cpu_use_percent >= 0.);
+    assert!(stat.value.mem_use_percent >= 0.);
 
     state_subscription
         .wait_for_state(BackendState::Swept, 60_000)

--- a/drone/src/agent/docker.rs
+++ b/drone/src/agent/docker.rs
@@ -193,6 +193,8 @@ impl DockerInterface {
         )
     }
 
+    /// The docker api (as of docker version 20.10.18) blocks for ~1s before returning
+    /// from self.docker.stats, hence the effective minimal interval is a second
     pub fn get_stats<'a>(
         &'a self,
         container_name: &'a str,

--- a/drone/src/agent/docker.rs
+++ b/drone/src/agent/docker.rs
@@ -18,6 +18,8 @@ use tokio_stream::{wrappers::IntervalStream, Stream, StreamExt};
 /// The port in the container which is exposed.
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
+/// Interval between reporting stats of a running backend.
+/// NOTE: the minimum possible interval is 1 second.
 const DEFAULT_DOCKER_STATS_INTERVAL_SECONDS: u64 = 10;
 
 #[derive(Clone)]

--- a/drone/src/agent/docker.rs
+++ b/drone/src/agent/docker.rs
@@ -18,7 +18,7 @@ use tokio_stream::{wrappers::IntervalStream, Stream, StreamExt};
 /// The port in the container which is exposed.
 const CONTAINER_PORT: u16 = 8080;
 const DEFAULT_DOCKER_TIMEOUT_SECONDS: u64 = 30;
-const DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS: u64 = 10;
+const DEFAULT_DOCKER_STATS_INTERVAL_SECONDS: u64 = 10;
 
 #[derive(Clone)]
 pub struct DockerInterface {
@@ -204,9 +204,7 @@ impl DockerInterface {
 
         IntervalStream::new(
             // call stats once for every INTERVAL
-            tokio::time::interval(Duration::from_secs(
-                DEFAULT_DOCKER_THROTTLED_STATS_INTERVAL_SECS,
-            )),
+            tokio::time::interval(Duration::from_secs(DEFAULT_DOCKER_STATS_INTERVAL_SECONDS)),
         )
         .then(move |_tick| async move {
             self.docker

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -191,7 +191,7 @@ impl Executor {
                     while let Some(cur_stats) = stream.next().await {
                         match cur_stats {
                             Ok(cur_stats) => {
-                                nc.publish(&BackendStatsMessage::from_stats_message(
+                                nc.publish(&BackendStatsMessage::from_stats_messages(
                                     &backend_id,
                                     &prev_stats,
                                     &cur_stats,

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -195,7 +195,7 @@ impl Executor {
                                     &backend_id,
                                     &prev_stats,
                                     &cur_stats,
-                                ))
+                                )?)
                                 .await?;
                                 prev_stats = cur_stats;
                             }

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -184,7 +184,7 @@ impl Executor {
                     let container_name = backend_id.to_resource_name();
                     tracing::info!(%backend_id, "Stats recording loop started.");
                     let mut stream = Box::pin(docker.get_stats(&container_name));
-                    let prev_stats = stream
+                    let mut prev_stats = stream
                         .next()
                         .await
                         .ok_or(anyhow!("failed to get first stats"))??;
@@ -196,7 +196,8 @@ impl Executor {
                                     &prev_stats,
                                     &cur_stats,
                                 ))
-                                .await?
+                                .await?;
+                                prev_stats = cur_stats;
                             }
                             Err(error) => {
                                 tracing::warn!(?error, "Error encountered sending stats.")


### PR DESCRIPTION
this PR moves from the streaming docker_stats api to a polling API, this solves the currently buggy backend_stats messages (throttling doesn't drop messages) and also cleans up the code a bunch since get_stats no longer need return an Option.