### PR TITLE
Allow scheduler to pick backend name (fixes #182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,6 @@ dependencies = [
  "dis-spawner",
  "tokio",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,4 +11,3 @@ tokio = { version = "1.21.2", features = ["macros", "rt", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 async-nats = "0.20.0"
 colored = "2.0.0"
-uuid = { version = "1.1.2", features = ["v4"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, time::Duration};
-
 use anyhow::Result;
 use async_nats::jetstream::consumer::DeliverPolicy;
 use clap::{Parser, Subcommand};
@@ -7,9 +5,9 @@ use colored::Colorize;
 use dis_spawner::{
     messages::{agent::DroneStatusMessage, scheduler::ScheduleRequest},
     nats_connection::NatsConnectionSpec,
-    types::{BackendId, ClusterName},
+    types::ClusterName,
 };
-use uuid::Uuid;
+use std::{collections::HashMap, time::Duration};
 
 #[derive(Parser)]
 struct Opts {
@@ -58,10 +56,9 @@ async fn main() -> Result<()> {
             }
         }
         Command::Spawn { image } => {
-            let backend_id = Uuid::new_v4().to_string();
             let result = nats
                 .request(&ScheduleRequest {
-                    backend_id: BackendId::new(backend_id),
+                    backend_id: None,
                     cluster: ClusterName::new(&opts.cluster),
                     image,
                     max_idle_secs: Duration::from_secs(30),

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -19,7 +19,7 @@ pub struct ScheduleRequest {
 
     /// The name of the backend. This forms part of the hostname used to
     /// connect to the drone.
-    pub backend_id: BackendId,
+    pub backend_id: Option<BackendId>,
 
     /// The timeout after which the drone is shut down if no connections are made.
     #[serde_as(as = "DurationSeconds")]
@@ -37,10 +37,15 @@ pub struct ScheduleRequest {
 
 impl ScheduleRequest {
     pub fn schedule(&self, drone_id: &DroneId) -> SpawnRequest {
+        let backend_id = self
+            .backend_id
+            .clone()
+            .unwrap_or_else(BackendId::new_random);
+
         SpawnRequest {
             drone_id: drone_id.clone(),
             image: self.image.clone(),
-            backend_id: self.backend_id.clone(),
+            backend_id: backend_id,
             max_idle_secs: self.max_idle_secs,
             env: self.env.clone(),
             metadata: self.metadata.clone(),
@@ -52,7 +57,10 @@ impl ScheduleRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ScheduleResponse {
-    Scheduled { drone: DroneId },
+    Scheduled {
+        drone: DroneId,
+        backend_id: BackendId,
+    },
     NoDroneAvailable,
 }
 

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -45,7 +45,7 @@ impl ScheduleRequest {
         SpawnRequest {
             drone_id: drone_id.clone(),
             image: self.image.clone(),
-            backend_id: backend_id,
+            backend_id,
             max_idle_secs: self.max_idle_secs,
             env: self.env.clone(),
             metadata: self.metadata.clone(),

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -62,6 +62,12 @@ impl BackendId {
             .strip_prefix(RESOURCE_PREFIX)
             .map(|d| BackendId(d.to_string()))
     }
+
+    #[must_use]
+    pub fn new_random() -> Self {
+        let id = Uuid::new_v4();
+        BackendId(id.to_string())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -1,4 +1,3 @@
-use crate::test_name;
 use anyhow::{anyhow, Result};
 use dis_spawner::messages::agent::SpawnRequest;
 use dis_spawner::messages::scheduler::ScheduleRequest;
@@ -38,10 +37,6 @@ pub fn random_loopback_ip() -> Ipv4Addr {
     let v3 = rng.gen_range(1..254);
 
     Ipv4Addr::new(127, v1, v2, v3)
-}
-
-pub fn random_backend_id(hint: &str) -> BackendId {
-    BackendId::new(random_prefix(hint))
 }
 
 pub async fn wait_for_port(addr: SocketAddrV4, timeout_ms: u128) -> Result<()> {
@@ -109,11 +104,10 @@ pub async fn wait_for_url(url: &str, timeout_ms: u128) -> Result<()> {
 const TEST_IMAGE: &str = "ghcr.io/drifting-in-space/test-image:latest";
 
 pub fn base_spawn_request() -> SpawnRequest {
-    let backend_id = random_backend_id(&test_name());
     SpawnRequest {
         drone_id: DroneId::new_random(),
         image: TEST_IMAGE.into(),
-        backend_id,
+        backend_id: BackendId::new_random(),
         max_idle_secs: Duration::from_secs(10),
         env: vec![("PORT".into(), "8080".into())].into_iter().collect(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),
@@ -123,11 +117,10 @@ pub fn base_spawn_request() -> SpawnRequest {
 }
 
 pub fn base_scheduler_request() -> ScheduleRequest {
-    let backend_id = random_backend_id(&test_name());
     ScheduleRequest {
         cluster: ClusterName::new("spawner.test"),
         image: TEST_IMAGE.into(),
-        backend_id,
+        backend_id: None,
         max_idle_secs: Duration::from_secs(10),
         env: vec![("PORT".into(), "8080".into())].into_iter().collect(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -48,8 +48,7 @@ impl MockAgent {
 
         // Ensure that the SpawnRequest is as expected.
         assert_eq!(
-            request.schedule(&drone_id),
-            result.value,
+            drone_id, &result.value.drone_id,
             "Scheduled drone did not match expectation."
         );
 
@@ -107,7 +106,7 @@ async fn one_drone_available() -> Result<()> {
         .await?;
 
     let result = mock_agent.schedule_drone(&drone_id).await?;
-    assert_eq!(ScheduleResponse::Scheduled { drone: drone_id }, result);
+    assert!(matches!(result, ScheduleResponse::Scheduled { drone, .. } if drone == drone_id));
 
     Ok(())
 }


### PR DESCRIPTION
Currently, whoever invokes `ScheduleRequest` is responsible for picking a backend. This still allows that behavior, but additionally allows them to leave the backend name as `None` to have a backend name auto-generated.

The caller will still need access to the backend which has been scheduled, so a `backend_id` field is added to `ScheduleResponse`.